### PR TITLE
Add basic CI using compilation tests and local tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+script:
+    - cd events-c
+    - make test


### PR DESCRIPTION
- Local tests (posix based) in Travis CI using `make test` in events-c
- Compilation test in Circle CI using [mbed-cli](https://github.com/armmbed/mbed-cli) with [mbed](https://github.com/mbedmicro/mbed)

The main missing tests from this setup is running actual tests on mbed hardware, which will require additional infrastructure.
