### PR TITLE
Moved delay/period to first argument of post_in/post_every

### DIFF
--- a/EventQueue.h
+++ b/EventQueue.h
@@ -81,31 +81,6 @@ public:
      *  @return         A positive id representing the event in the queue,
      *                  or 0 on failure
      */
-    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
-    int post(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-        return post(Context5<F,A0,A1,A2,A3,A4>(f,a0,a1,a2,a3,a4));
-    }
-
-    template <typename F, typename A0, typename A1, typename A2, typename A3>
-    int post(F f, A0 a0, A1 a1, A2 a2, A3 a3) {
-        return post(Context4<F,A0,A1,A2,A3>(f,a0,a1,a2,a3));
-    }
-
-    template <typename F, typename A0, typename A1, typename A2>
-    int post(F f, A0 a0, A1 a1, A2 a2) {
-        return post(Context3<F,A0,A1,A2>(f,a0,a1,a2));
-    }
-
-    template <typename F, typename A0, typename A1>
-    int post(F f, A0 a0, A1 a1) {
-        return post(Context2<F,A0,A1>(f,a0,a1));
-    }
-
-    template <typename F, typename A0>
-    int post(F f, A0 a0) {
-        return post(Context1<F,A0>(f,a0));
-    }
-
     template <typename F>
     int post(F f) {
         void *p = event_alloc(&_equeue, sizeof(F));
@@ -118,6 +93,31 @@ public:
         return event_post(&_equeue, &EventQueue::call<F>, e);
     }
 
+    template <typename F, typename A0>
+    int post(F f, A0 a0) {
+        return post(Context1<F,A0>(f,a0));
+    }
+
+    template <typename F, typename A0, typename A1>
+    int post(F f, A0 a0, A1 a1) {
+        return post(Context2<F,A0,A1>(f,a0,a1));
+    }
+
+    template <typename F, typename A0, typename A1, typename A2>
+    int post(F f, A0 a0, A1 a1, A2 a2) {
+        return post(Context3<F,A0,A1,A2>(f,a0,a1,a2));
+    }
+
+    template <typename F, typename A0, typename A1, typename A2, typename A3>
+    int post(F f, A0 a0, A1 a1, A2 a2, A3 a3) {
+        return post(Context4<F,A0,A1,A2,A3>(f,a0,a1,a2,a3));
+    }
+
+    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
+    int post(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+        return post(Context5<F,A0,A1,A2,A3,A4>(f,a0,a1,a2,a3,a4));
+    }
+
     /** Post an event to the queue after a specified delay
      *
      *  @param f        Function to call on event dispatch
@@ -126,31 +126,6 @@ public:
      *  @return         A positive id representing the event in the queue,
      *                  or 0 on failure
      */
-    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
-    int post_in(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-        return post_in(ms, Context5<F,A0,A1,A2,A3,A4>(f,a0,a1,a2,a3,a4));
-    }
-
-    template <typename F, typename A0, typename A1, typename A2, typename A3>
-    int post_in(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3) {
-        return post_in(ms, Context4<F,A0,A1,A2,A3>(f,a0,a1,a2,a3));
-    }
-
-    template <typename F, typename A0, typename A1, typename A2>
-    int post_in(int ms, F f, A0 a0, A1 a1, A2 a2) {
-        return post_in(ms, Context3<F,A0,A1,A2>(f,a0,a1,a2));
-    }
-
-    template <typename F, typename A0, typename A1>
-    int post_in(int ms, F f, A0 a0, A1 a1) {
-        return post_in(ms, Context2<F,A0,A1>(f,a0,a1));
-    }
-
-    template <typename F, typename A0>
-    int post_in(int ms, F f, A0 a0) {
-        return post_in(ms, Context1<F,A0>(f,a0));
-    }
-
     template <typename F>
     int post_in(int ms, F f) {
         void *p = event_alloc(&_equeue, sizeof(F));
@@ -164,6 +139,31 @@ public:
         return event_post(&_equeue, &EventQueue::call<F>, e);
     }
 
+    template <typename F, typename A0>
+    int post_in(int ms, F f, A0 a0) {
+        return post_in(ms, Context1<F,A0>(f,a0));
+    }
+
+    template <typename F, typename A0, typename A1>
+    int post_in(int ms, F f, A0 a0, A1 a1) {
+        return post_in(ms, Context2<F,A0,A1>(f,a0,a1));
+    }
+
+    template <typename F, typename A0, typename A1, typename A2>
+    int post_in(int ms, F f, A0 a0, A1 a1, A2 a2) {
+        return post_in(ms, Context3<F,A0,A1,A2>(f,a0,a1,a2));
+    }
+
+    template <typename F, typename A0, typename A1, typename A2, typename A3>
+    int post_in(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3) {
+        return post_in(ms, Context4<F,A0,A1,A2,A3>(f,a0,a1,a2,a3));
+    }
+
+    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
+    int post_in(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+        return post_in(ms, Context5<F,A0,A1,A2,A3,A4>(f,a0,a1,a2,a3,a4));
+    }
+
     /** Post an event to the queue periodically
      *
      *  @param f        Function to call on event dispatch
@@ -172,31 +172,6 @@ public:
      *  @return         A positive id representing the event in the queue,
      *                  or 0 on failure
      */
-    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
-    int post_every(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-        return post_every(ms, Context5<F,A0,A1,A2,A3,A4>(f,a0,a1,a2,a3,a4));
-    }
-
-    template <typename F, typename A0, typename A1, typename A2, typename A3>
-    int post_every(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3) {
-        return post_every(ms, Context4<F,A0,A1,A2,A3>(f,a0,a1,a2,a3));
-    }
-
-    template <typename F, typename A0, typename A1, typename A2>
-    int post_every(int ms, F f, A0 a0, A1 a1, A2 a2) {
-        return post_every(ms, Context3<F,A0,A1,A2>(f,a0,a1,a2));
-    }
-
-    template <typename F, typename A0, typename A1>
-    int post_every(int ms, F f, A0 a0, A1 a1) {
-        return post_every(ms, Context2<F,A0,A1>(f,a0,a1));
-    }
-
-    template <typename F, typename A0>
-    int post_every(int ms, F f, A0 a0) {
-        return post_every(ms, Context1<F,A0>(f,a0));
-    }
-
     template <typename F>
     int post_every(int ms, F f) {
         void *p = event_alloc(&_equeue, sizeof(F));
@@ -211,6 +186,30 @@ public:
         return event_post(&_equeue, &EventQueue::call<F>, e);
     }
 
+    template <typename F, typename A0>
+    int post_every(int ms, F f, A0 a0) {
+        return post_every(ms, Context1<F,A0>(f,a0));
+    }
+
+    template <typename F, typename A0, typename A1>
+    int post_every(int ms, F f, A0 a0, A1 a1) {
+        return post_every(ms, Context2<F,A0,A1>(f,a0,a1));
+    }
+
+    template <typename F, typename A0, typename A1, typename A2>
+    int post_every(int ms, F f, A0 a0, A1 a1, A2 a2) {
+        return post_every(ms, Context3<F,A0,A1,A2>(f,a0,a1,a2));
+    }
+
+    template <typename F, typename A0, typename A1, typename A2, typename A3>
+    int post_every(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3) {
+        return post_every(ms, Context4<F,A0,A1,A2,A3>(f,a0,a1,a2,a3));
+    }
+
+    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
+    int post_every(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+        return post_every(ms, Context5<F,A0,A1,A2,A3,A4>(f,a0,a1,a2,a3,a4));
+    }
 
 protected:
     void break_();

--- a/EventQueue.h
+++ b/EventQueue.h
@@ -127,32 +127,32 @@ public:
      *                  or 0 on failure
      */
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
-    int post_in(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4, int ms) {
-        return post_in(Context5<F,A0,A1,A2,A3,A4>(f,a0,a1,a2,a3,a4), ms);
+    int post_in(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+        return post_in(ms, Context5<F,A0,A1,A2,A3,A4>(f,a0,a1,a2,a3,a4));
     }
 
     template <typename F, typename A0, typename A1, typename A2, typename A3>
-    int post_in(F f, A0 a0, A1 a1, A2 a2, A3 a3, int ms) {
-        return post_in(Context4<F,A0,A1,A2,A3>(f,a0,a1,a2,a3), ms);
+    int post_in(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3) {
+        return post_in(ms, Context4<F,A0,A1,A2,A3>(f,a0,a1,a2,a3));
     }
 
     template <typename F, typename A0, typename A1, typename A2>
-    int post_in(F f, A0 a0, A1 a1, A2 a2, int ms) {
-        return post_in(Context3<F,A0,A1,A2>(f,a0,a1,a2), ms);
+    int post_in(int ms, F f, A0 a0, A1 a1, A2 a2) {
+        return post_in(ms, Context3<F,A0,A1,A2>(f,a0,a1,a2));
     }
 
     template <typename F, typename A0, typename A1>
-    int post_in(F f, A0 a0, A1 a1, int ms) {
-        return post_in(Context2<F,A0,A1>(f,a0,a1), ms);
+    int post_in(int ms, F f, A0 a0, A1 a1) {
+        return post_in(ms, Context2<F,A0,A1>(f,a0,a1));
     }
 
     template <typename F, typename A0>
-    int post_in(F f, A0 a0, int ms) {
-        return post_in(Context1<F,A0>(f,a0), ms);
+    int post_in(int ms, F f, A0 a0) {
+        return post_in(ms, Context1<F,A0>(f,a0));
     }
 
     template <typename F>
-    int post_in(F f, int ms) {
+    int post_in(int ms, F f) {
         void *p = event_alloc(&_equeue, sizeof(F));
         if (!p) {
             return 0;
@@ -173,32 +173,32 @@ public:
      *                  or 0 on failure
      */
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
-    int post_every(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4, int ms) {
-        return post_every(Context5<F,A0,A1,A2,A3,A4>(f,a0,a1,a2,a3,a4), ms);
+    int post_every(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+        return post_every(ms, Context5<F,A0,A1,A2,A3,A4>(f,a0,a1,a2,a3,a4));
     }
 
     template <typename F, typename A0, typename A1, typename A2, typename A3>
-    int post_every(F f, A0 a0, A1 a1, A2 a2, A3 a3, int ms) {
-        return post_every(Context4<F,A0,A1,A2,A3>(f,a0,a1,a2,a3), ms);
+    int post_every(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3) {
+        return post_every(ms, Context4<F,A0,A1,A2,A3>(f,a0,a1,a2,a3));
     }
 
     template <typename F, typename A0, typename A1, typename A2>
-    int post_every(F f, A0 a0, A1 a1, A2 a2, int ms) {
-        return post_every(Context3<F,A0,A1,A2>(f,a0,a1,a2), ms);
+    int post_every(int ms, F f, A0 a0, A1 a1, A2 a2) {
+        return post_every(ms, Context3<F,A0,A1,A2>(f,a0,a1,a2));
     }
 
     template <typename F, typename A0, typename A1>
-    int post_every(F f, A0 a0, A1 a1, int ms) {
-        return post_every(Context2<F,A0,A1>(f,a0,a1), ms);
+    int post_every(int ms, F f, A0 a0, A1 a1) {
+        return post_every(ms, Context2<F,A0,A1>(f,a0,a1));
     }
 
     template <typename F, typename A0>
-    int post_every(F f, A0 a0, int ms) {
-        return post_every(Context1<F,A0>(f,a0), ms);
+    int post_every(int ms, F f, A0 a0) {
+        return post_every(ms, Context1<F,A0>(f,a0));
     }
 
     template <typename F>
-    int post_every(F f, int ms) {
+    int post_every(int ms, F f) {
         void *p = event_alloc(&_equeue, sizeof(F));
         if (!p) {
             return 0;

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ int main() {
 
     // events are simple callbacks
     queue.post(printf, "called immediately\n");
-    queue.post_in(printf, "called in 2 seconds\n", 2000);
-    queue.post_every(printf, "called every 1 seconds\n", 1000);
+    queue.post_in(printf, 2000, "called in 2 seconds\n");
+    queue.post_every(printf, 1000, "called every 1 seconds\n");
 
     // executed by the dispatch method
     queue.dispatch();
@@ -68,13 +68,13 @@ queue.post(Callback<void(char)>(&serial, &Serial::printf), "hello\n");
 
 // The post_in function registers events to be called after a delay
 // specified in milliseconds
-queue.post_in(doit_in_two_seconds, 2000);
-queue.post_in(printf, "called in 0.3 seconds\n", 300);
+queue.post_in(2000, doit_in_two_seconds);
+queue.post_in(300, printf, "called in 0.3 seconds\n");
 
 // The post_every function registers events to be called repeatedly
 // with a period specified in milliseconds
-queue.post_every(doit_every_two_seconds, 2000);
-queue.post_every(printf, "called every 0.4 seconds\n", 400);
+queue.post_every(2000, doit_every_two_seconds);
+queue.post_every(400, printf, "called every 0.4 seconds\n");
 ```
 
 All post calls return an integer id that uniquely represents the event
@@ -83,7 +83,7 @@ there is no memory or the queue's event size is exceeded.
 
 ``` cpp
 // The event id is uniqueue to the queue
-int id = queue.post_in(printf, "will this work?\n", 100);
+int id = queue.post_in(100, printf, "will this work?\n");
 
 // An id of 0 indicates an error
 if (id) {

--- a/TESTS/events/queue/main.cpp
+++ b/TESTS/events/queue/main.cpp
@@ -51,12 +51,12 @@ void simple_posts_test##i() {                               \
     TEST_ASSERT(touched);                                   \
                                                             \
     touched = false;                                        \
-    queue.post_in(func##i,##__VA_ARGS__, 1);                \
+    queue.post_in(1, func##i,##__VA_ARGS__);                \
     queue.dispatch(2);                                      \
     TEST_ASSERT(touched);                                   \
                                                             \
     touched = false;                                        \
-    queue.post_every(func##i,##__VA_ARGS__, 1);             \
+    queue.post_every(1, func##i,##__VA_ARGS__);             \
     queue.dispatch(2);                                      \
     TEST_ASSERT(touched);                                   \
 }
@@ -82,7 +82,7 @@ void post_in_test() {
 
     for (int i = 0; i < N; i++) {
         tickers[i].start();
-        queue.post_in(time_func, &tickers[i], (i+1)*100, (i+1)*100);
+        queue.post_in((i+1)*100, time_func, &tickers[i], (i+1)*100);
     }
 
     queue.dispatch(N*100);
@@ -96,7 +96,7 @@ void post_every_test() {
 
     for (int i = 0; i < N; i++) {
         tickers[i].start();
-        queue.post_every(time_func, &tickers[i], (i+1)*100, (i+1)*100);
+        queue.post_every((i+1)*100, time_func, &tickers[i], (i+1)*100);
     }
 
     queue.dispatch(N*100);
@@ -127,7 +127,7 @@ void event_loop_test2() {
 
     for (int i = 0; i < N; i++) {
         tickers[i].start();
-        loop.post_every(time_func, &tickers[i], (i+1)*100, (i+1)*100);
+        loop.post_every((i+1)*100, time_func, &tickers[i], (i+1)*100);
         Thread::yield();
         wait_ms(75);
     }
@@ -166,7 +166,7 @@ void cancel_test1() {
     int ids[N];
 
     for (int i = 0; i < N; i++) {
-        ids[i] = queue.post_in(no, 1000);
+        ids[i] = queue.post_in(1000, no);
     }
 
     for (int i = N-1; i >= 0; i--) {
@@ -186,7 +186,7 @@ void cancel_test2() {
     int ids[N];
 
     for (int i = 0; i < N; i++) {
-        ids[i] = loop.post_in(no, 1000);
+        ids[i] = loop.post_in(1000, no);
     }
 
     for (int i = N-1; i >= 0; i--) {


### PR DESCRIPTION
per suggestion from @kilogram, and I believe @pan- had similar concerns with the initial design
- makes the call clearer, especially when callback argument looks like a delay value
- simplifies implementation of c++11 wrappers

matches previous change in c api (https://github.com/geky/events/issues/3, https://github.com/geky/events/pull/4)
