### PR TITLE
remove unvwanted return statment

### DIFF
--- a/events-c/events.c
+++ b/events-c/events.c
@@ -279,7 +279,7 @@ int event_post(equeue_t *q, void (*cb)(void*), void *p) {
 }
 
 void event_cancel(equeue_t *q, int id) {
-    return equeue_cancel(q, id);
+    equeue_cancel(q, id);
 }
 
 // simple callbacks 


### PR DESCRIPTION
C function: void event_cancel(... had unwanted return statement.
It cause build crash for IAR.
