### PR TITLE
Add additional tests/profiling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,3 @@
 script:
+    - CFLAGS='-pedantic -Werror' make
     - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,15 @@
 script:
+      # Strict compilation of library
     - CFLAGS='-pedantic -Werror' make
+
+      # Runtime tests
     - make test
+
+      # Relative profiling with current master
+    - if ( git clone https://github.com/geky/events tests/master &&
+           make -s -C tests/master prof | tee tests/results.txt ) ;
+      then
+        cat tests/results.txt | make prof ; 
+      else
+        make prof ;
+      fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,17 @@
 script:
     - cd events-c
+
+      # Strict compilation of library
+    - CFLAGS='-pedantic -Werror' make
+
+      # Runtime tests
     - make test
+
+      # Relative profiling with current master
+    - if ( git clone https://github.com/armmbed/mbed-events tests/master &&
+           make -s -C tests/master/$(basename $(pwd)) prof | tee tests/results.txt ) ;
+      then
+        cat tests/results.txt | make prof ; 
+      else
+        make prof ;
+      fi

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,7 @@ DEP := $(SRC:.c=.d)
 ASM := $(SRC:.c=.s)
 
 ifdef DEBUG
-CFLAGS += -O0 -g3 -DMU_DEBUG
-CFLAGS += -fkeep-inline-functions
+CFLAGS += -O0 -g3
 else
 CFLAGS += -O2
 endif
@@ -20,7 +19,7 @@ CFLAGS += -m$(WORD)
 endif
 CFLAGS += -I.
 CFLAGS += -std=c99
-CFLAGS += -Wall -Winline
+CFLAGS += -Wall
 CFLAGS += -D_XOPEN_SOURCE=500
 
 LFLAGS += -lpthread

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,6 @@ OBJ := $(SRC:.c=.o)
 DEP := $(SRC:.c=.d)
 ASM := $(SRC:.c=.s)
 
-TESTS = tests/tests
-TSRC += $(wildcard tests/*.c)
-TOBJ := $(TSRC:.c=.o)
-TDEP := $(TSRC:.c=.d)
-
 ifdef DEBUG
 CFLAGS += -O0 -g3 -DMU_DEBUG
 CFLAGS += -fkeep-inline-functions
@@ -33,9 +28,13 @@ LFLAGS += -lpthread
 
 all: $(TARGET)
 
-test: $(TOBJ) $(OBJ)
-	$(CC) $(CFLAGS) $^ $(LFLAGS) -o $(TESTS)
-	$(TESTS)
+test: tests/tests.o $(OBJ)
+	$(CC) $(CFLAGS) $^ $(LFLAGS) -o tests/tests
+	tests/tests
+
+prof: tests/prof.o $(OBJ)
+	$(CC) $(CFLAGS) $^ $(LFLAGS) -o tests/prof
+	tests/prof
 
 asm: $(ASM)
 
@@ -55,8 +54,8 @@ size: $(OBJ)
 
 clean:
 	rm -f $(TARGET)
-	rm -f $(TESTS)
-	rm -f $(TOBJ) $(TDEP)
+	rm -f tests/tests tests/tests.o tests/tests.d
+	rm -f tests/prof tests/prof.o tests/prof.d
 	rm -f $(OBJ)
 	rm -f $(DEP)
 	rm -f $(ASM)

--- a/README.md
+++ b/README.md
@@ -37,13 +37,32 @@ supports multithreaded environments. More information on the idea
 behind composable event loops 
 [here](https://gist.github.com/geky/4969d940f1bd5596bdc10e79093e2553).
 
+## Tests ##
+
+The events library uses a set of local tests based on the posix implementation.
+
+Runtime tests are located in [tests.c](tests/tests.c):
+
+``` bash
+make test
+```
+
+Profiling tests based on rdtsc are located in [prof.c](tests/prof.c):
+
+``` bash
+make prof
+```
+
+To make profiling results more tangible, the profiler also supports percentage
+comparison with previous runs:
+``` bash
+make prof | tee results.txt
+cat results.txt | make prof
+```
+
 ## Porting ##
 
-The events library only requires the following:
-- monotonic counter
-- non-recursive mutex
-- binary semaphore
-
-Supported implementations are hosted as branches on this repo:
-- Posix
-- mbed
+The events library requires a small porting layer:
+- [events_tick](events_tick.h) - monotonic counter
+- [events_mutex](events_mutex.h) - non-recursive mutex
+- [events_sema](events_sema.h) - binary semaphore

--- a/events.c
+++ b/events.c
@@ -284,7 +284,7 @@ int event_post(equeue_t *q, void (*cb)(void*), void *p) {
 }
 
 void event_cancel(equeue_t *q, int id) {
-    return equeue_cancel(q, id);
+    equeue_cancel(q, id);
 }
 
 // simple callbacks 

--- a/tests/prof.c
+++ b/tests/prof.c
@@ -1,0 +1,354 @@
+#include "events.h"
+#include <unistd.h>
+#include <stdio.h>
+#include <setjmp.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <inttypes.h>
+#include <sys/time.h>
+
+
+// Performance measurement utils
+#define PROF_RUNS 5
+#define PROF_INTERVAL 100000000
+
+#define prof_volatile(t) __attribute__((unused)) volatile t
+
+typedef uint64_t prof_cycle_t;
+
+static volatile prof_cycle_t prof_start_cycle;
+static volatile prof_cycle_t prof_stop_cycle;
+static prof_cycle_t prof_accum_cycle;
+static prof_cycle_t prof_baseline_cycle;
+static prof_cycle_t prof_iterations;
+static const char *prof_units;
+
+#define prof_cycle() ({                                                     \
+    uint32_t a, b;                                                          \
+    __asm__ volatile ("rdtsc" : "=a" (a), "=d" (b));                        \
+    ((uint64_t)b << 32) | (uint64_t)a;                                      \
+})
+
+#define prof_loop()                                                         \
+    for (prof_iterations = 0;                                               \
+         prof_accum_cycle < PROF_INTERVAL;                                  \
+         prof_iterations++)
+
+#define prof_start() ({                                                     \
+    prof_start_cycle = prof_cycle();                                        \
+})
+
+#define prof_stop() ({                                                      \
+    prof_stop_cycle = prof_cycle();                                         \
+    prof_accum_cycle += prof_stop_cycle - prof_start_cycle;                 \
+})
+
+#define prof_result(value, units) ({                                        \
+    prof_accum_cycle = value+prof_baseline_cycle;                           \
+    prof_iterations = 1;                                                    \
+    prof_units = units;                                                     \
+})
+
+#define prof_measure(func, ...) ({                                          \
+    printf("%s: ...", #func);                                               \
+    fflush(stdout);                                                         \
+                                                                            \
+    prof_units = "cycles";                                                  \
+    prof_cycle_t runs[PROF_RUNS];                                           \
+    for (int i = 0; i < PROF_RUNS; i++) {                                   \
+        prof_accum_cycle = 0;                                               \
+        prof_iterations = 0;                                                \
+        func(__VA_ARGS__);                                                  \
+        runs[i] = prof_accum_cycle / prof_iterations;                       \
+    }                                                                       \
+                                                                            \
+    prof_cycle_t res = runs[0];                                             \
+    for (int i = 0; i < PROF_RUNS; i++) {                                   \
+        if (runs[i] < res) {                                                \
+            res = runs[i];                                                  \
+        }                                                                   \
+    }                                                                       \
+    res -= prof_baseline_cycle;                                             \
+    printf("\r%s: %"PRIu64" %s", #func, res, prof_units);                   \
+                                                                            \
+    if (!isatty(0)) {                                                       \
+        prof_cycle_t prev;                                                  \
+        while (scanf("%*[^0-9]%"PRIu64, &prev) == 0);                       \
+        int64_t perc = 100*((int64_t)prev - (int64_t)res) / (int64_t)prev;  \
+                                                                            \
+        if (perc > 10) {                                                    \
+            printf(" (\e[32m%+"PRId64"%%\e[0m)", perc);                     \
+        } else if (perc < -10) {                                            \
+            printf(" (\e[31m%+"PRId64"%%\e[0m)", perc);                     \
+        } else {                                                            \
+            printf(" (%+"PRId64"%%)", perc);                                \
+        }                                                                   \
+    }                                                                       \
+                                                                            \
+    printf("\n");                                                           \
+    res;                                                                    \
+})
+
+#define prof_baseline(func, ...) ({                                         \
+    prof_baseline_cycle = 0;                                                \
+    prof_baseline_cycle = prof_measure(func, __VA_ARGS__);                  \
+})
+
+
+// Various test functions
+void no_func(void *eh) {
+}
+
+
+// Actual performance tests
+void baseline_prof(void) {
+    prof_loop() {
+        prof_start();
+        __asm__ volatile ("");
+        prof_stop();
+    }
+}
+
+void events_tick_prof(void) {
+    prof_volatile(unsigned) res;
+    prof_loop() {
+        prof_start();
+        res = events_tick();
+        prof_stop();
+    }
+}
+
+void event_alloc_prof(void) {
+    struct equeue q;
+    equeue_create(&q, 2*32*sizeof(struct event));
+
+    prof_loop() {
+        prof_start();
+        void *e = event_alloc(&q, 8 * sizeof(int));
+        prof_stop();
+
+        event_dealloc(&q, e);
+    }
+
+    equeue_destroy(&q);
+}
+
+void event_alloc_many_prof(int count) {
+    struct equeue q;
+    equeue_create(&q, 2*count*sizeof(struct event));
+
+    void *es[count];
+
+    for (int i = 0; i < count; i++) {
+        es[i] = event_alloc(&q, (i % 4) * sizeof(int));
+    }
+
+    for (int i = 0; i < count; i++) {
+        event_dealloc(&q, es[i]);
+    }
+
+    prof_loop() {
+        prof_start();
+        void *e = event_alloc(&q, 8 * sizeof(int));
+        prof_stop();
+
+        event_dealloc(&q, e);
+    }
+
+    equeue_destroy(&q);
+}
+
+void event_post_prof(void) {
+    struct equeue q;
+    equeue_create(&q, 2*sizeof(struct event));
+
+    prof_loop() {
+        void *e = event_alloc(&q, 0);
+
+        prof_start();
+        int id = event_post(&q, no_func, e);
+        prof_stop();
+
+        event_cancel(&q, id);
+    }
+
+    equeue_destroy(&q);
+}
+
+void event_post_many_prof(int count) {
+    struct equeue q;
+    equeue_create(&q, 2*count*sizeof(struct event));
+
+    for (int i = 0; i < count; i++) {
+        event_call(&q, no_func, 0);
+    }
+
+    prof_loop() {
+        void *e = event_alloc(&q, 0);
+
+        prof_start();
+        int id = event_post(&q, no_func, e);
+        prof_stop();
+
+        event_cancel(&q, id);
+    }
+
+    equeue_destroy(&q);
+}
+
+void event_post_future_prof(void) {
+    struct equeue q;
+    equeue_create(&q, 2*sizeof(struct event));
+
+    prof_loop() {
+        void *e = event_alloc(&q, 0);
+        event_delay(e, 1000);
+
+        prof_start();
+        int id = event_post(&q, no_func, e);
+        prof_stop();
+
+        event_cancel(&q, id);
+    }
+
+    equeue_destroy(&q);
+}
+
+void event_post_future_many_prof(int count) {
+    struct equeue q;
+    equeue_create(&q, 2*count*sizeof(struct event));
+
+    for (int i = 0; i < count; i++) {
+        event_call(&q, no_func, 0);
+    }
+
+    prof_loop() {
+        void *e = event_alloc(&q, 0);
+        event_delay(e, 1000);
+
+        prof_start();
+        int id = event_post(&q, no_func, e);
+        prof_stop();
+
+        event_cancel(&q, id);
+    }
+
+    equeue_destroy(&q);
+}
+
+void equeue_dispatch_prof(void) {
+    struct equeue q;
+    equeue_create(&q, 2*sizeof(struct event));
+
+    prof_loop() {
+        event_call(&q, no_func, 0);
+
+        prof_start();
+        equeue_dispatch(&q, 0);
+        prof_stop();
+    }
+
+    equeue_destroy(&q);
+}
+
+void equeue_dispatch_many_prof(int count) {
+    struct equeue q;
+    equeue_create(&q, 2*count*sizeof(struct event));
+
+    prof_loop() {
+        for (int i = 0; i < count; i++) {
+            event_call(&q, no_func, 0);
+        }
+
+        prof_start();
+        equeue_dispatch(&q, 0);
+        prof_stop();
+    }
+
+    equeue_destroy(&q);
+}
+
+void event_alloc_size_prof(void) {
+    size_t size = 2*32*sizeof(struct event);
+
+    struct equeue q;
+    equeue_create(&q, size);
+    event_alloc(&q, 0);
+
+    prof_result(size - q.slab.size, "bytes");
+
+    equeue_destroy(&q);
+}
+
+void event_alloc_many_size_prof(int count) {
+    size_t size = 2*count*sizeof(struct event);
+
+    struct equeue q;
+    equeue_create(&q, size);
+
+    for (int i = 0; i < count; i++) {
+        event_alloc(&q, (i % 4) * sizeof(int));
+    }
+
+    prof_result(size - q.slab.size, "bytes");
+
+    equeue_destroy(&q);
+}
+
+void event_alloc_fragmented_size_prof(int count) {
+    size_t size = 2*count*sizeof(struct event);
+
+    struct equeue q;
+    equeue_create(&q, size);
+
+    void *es[count];
+
+    for (int i = 0; i < count; i++) {
+        es[i] = event_alloc(&q, (i % 4) * sizeof(int));
+    }
+
+    for (int i = 0; i < count; i++) {
+        event_dealloc(&q, es[i]);
+    }
+
+    for (int i = count-1; i >= 0; i--) {
+        es[i] = event_alloc(&q, (i % 4) * sizeof(int));
+    }
+
+    for (int i = count-1; i >= 0; i--) {
+        event_dealloc(&q, es[i]);
+    }
+
+    for (int i = 0; i < count; i++) {
+        event_alloc(&q, (i % 4) * sizeof(int));
+    }
+
+    prof_result(size - q.slab.size, "bytes");
+
+    equeue_destroy(&q);
+}
+
+
+// Entry point
+int main() {
+    printf("beginning profiling...\n");
+
+    prof_baseline(baseline_prof);
+
+    prof_measure(events_tick_prof);
+    prof_measure(event_alloc_prof);
+    prof_measure(event_post_prof);
+    prof_measure(event_post_future_prof);
+    prof_measure(equeue_dispatch_prof);
+
+    prof_measure(event_alloc_many_prof, 1000);
+    prof_measure(event_post_many_prof, 1000);
+    prof_measure(event_post_future_many_prof, 1000);
+    prof_measure(equeue_dispatch_many_prof, 100);
+
+    prof_measure(event_alloc_size_prof);
+    prof_measure(event_alloc_many_size_prof, 1000);
+    prof_measure(event_alloc_fragmented_size_prof, 1000);
+
+    printf("done!\n");
+}


### PR DESCRIPTION
Five different tests are now available:
- Compilation of mbed-events with [mbedmicro/mbed](https://github.com/mbedmicro/mbed).
  
  ``` bash
  mbed compile --library -t GCC_ARM -m K64F
  ```
- Runtime tests in [TESTS/events/queue/main.cpp](https://github.com/ARMmbed/mbed-events/blob/tests/TESTS/events/queue/main.cpp).
  
  ``` bash
  mbed add https://github.com/mbedmicro/mbed
  mbed compile -t GCC_ARM -m K64F --source=. --source=TESTS/events/queue/
  sudo pyocd-flashtool .build/K64F/GCC_ARM/*.bin
  mbedhtrun --skip-flashing --skip-reset --port=/dev/ttyACM0:9600
  ```
- Strict c99 pedantic compilation of events-c. This should help prevent issues such as #3.
  
  ``` bash
  CFLAGS='-pedantic -Werror' make -C events-c
  ```
- Runtime tests in [events-c/tests/tests.c](https://github.com/ARMmbed/mbed-events/blob/tests/events-c/tests/tests.c).
  
  ``` bash
  make -C events-c test
  ```
- Profiling in [events-c/tests/prof.c](https://github.com/ARMmbed/mbed-events/blob/tests/events-c/tests/prof.c) (viewable in [travis.ci](https://travis-ci.org/ARMmbed/mbed-events/builds/144734246)). More info [here](https://github.com/ARMmbed/mbed-events/commit/ba0c701a36385df9b8a6df35558911f4a29ea1c3).
  
  ``` bash
  make -C events-c prof
  ```

Every test is supported CI except for runtime tests for mbed-events due to hardware requirements.
