### PR TITLE
Rename post -> call functions

### DIFF
--- a/EventQueue.h
+++ b/EventQueue.h
@@ -88,7 +88,7 @@ public:
      *                  or 0 on failure
      */
     template <typename F>
-    int post(F f) {
+    int call(F f) {
         void *p = event_alloc(&_equeue, sizeof(F));
         if (!p) {
             return 0;
@@ -100,28 +100,28 @@ public:
     }
 
     template <typename F, typename A0>
-    int post(F f, A0 a0) {
-        return post(Context1<F,A0>(f,a0));
+    int call(F f, A0 a0) {
+        return call(Context1<F,A0>(f,a0));
     }
 
     template <typename F, typename A0, typename A1>
-    int post(F f, A0 a0, A1 a1) {
-        return post(Context2<F,A0,A1>(f,a0,a1));
+    int call(F f, A0 a0, A1 a1) {
+        return call(Context2<F,A0,A1>(f,a0,a1));
     }
 
     template <typename F, typename A0, typename A1, typename A2>
-    int post(F f, A0 a0, A1 a1, A2 a2) {
-        return post(Context3<F,A0,A1,A2>(f,a0,a1,a2));
+    int call(F f, A0 a0, A1 a1, A2 a2) {
+        return call(Context3<F,A0,A1,A2>(f,a0,a1,a2));
     }
 
     template <typename F, typename A0, typename A1, typename A2, typename A3>
-    int post(F f, A0 a0, A1 a1, A2 a2, A3 a3) {
-        return post(Context4<F,A0,A1,A2,A3>(f,a0,a1,a2,a3));
+    int call(F f, A0 a0, A1 a1, A2 a2, A3 a3) {
+        return call(Context4<F,A0,A1,A2,A3>(f,a0,a1,a2,a3));
     }
 
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
-    int post(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-        return post(Context5<F,A0,A1,A2,A3,A4>(f,a0,a1,a2,a3,a4));
+    int call(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+        return call(Context5<F,A0,A1,A2,A3,A4>(f,a0,a1,a2,a3,a4));
     }
 
     /** Post an event to the queue after a specified delay
@@ -133,7 +133,7 @@ public:
      *                  or 0 on failure
      */
     template <typename F>
-    int post_in(int ms, F f) {
+    int call_in(int ms, F f) {
         void *p = event_alloc(&_equeue, sizeof(F));
         if (!p) {
             return 0;
@@ -146,28 +146,28 @@ public:
     }
 
     template <typename F, typename A0>
-    int post_in(int ms, F f, A0 a0) {
-        return post_in(ms, Context1<F,A0>(f,a0));
+    int call_in(int ms, F f, A0 a0) {
+        return call_in(ms, Context1<F,A0>(f,a0));
     }
 
     template <typename F, typename A0, typename A1>
-    int post_in(int ms, F f, A0 a0, A1 a1) {
-        return post_in(ms, Context2<F,A0,A1>(f,a0,a1));
+    int call_in(int ms, F f, A0 a0, A1 a1) {
+        return call_in(ms, Context2<F,A0,A1>(f,a0,a1));
     }
 
     template <typename F, typename A0, typename A1, typename A2>
-    int post_in(int ms, F f, A0 a0, A1 a1, A2 a2) {
-        return post_in(ms, Context3<F,A0,A1,A2>(f,a0,a1,a2));
+    int call_in(int ms, F f, A0 a0, A1 a1, A2 a2) {
+        return call_in(ms, Context3<F,A0,A1,A2>(f,a0,a1,a2));
     }
 
     template <typename F, typename A0, typename A1, typename A2, typename A3>
-    int post_in(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3) {
-        return post_in(ms, Context4<F,A0,A1,A2,A3>(f,a0,a1,a2,a3));
+    int call_in(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3) {
+        return call_in(ms, Context4<F,A0,A1,A2,A3>(f,a0,a1,a2,a3));
     }
 
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
-    int post_in(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-        return post_in(ms, Context5<F,A0,A1,A2,A3,A4>(f,a0,a1,a2,a3,a4));
+    int call_in(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+        return call_in(ms, Context5<F,A0,A1,A2,A3,A4>(f,a0,a1,a2,a3,a4));
     }
 
     /** Post an event to the queue periodically
@@ -179,7 +179,7 @@ public:
      *                  or 0 on failure
      */
     template <typename F>
-    int post_every(int ms, F f) {
+    int call_every(int ms, F f) {
         void *p = event_alloc(&_equeue, sizeof(F));
         if (!p) {
             return 0;
@@ -193,28 +193,28 @@ public:
     }
 
     template <typename F, typename A0>
-    int post_every(int ms, F f, A0 a0) {
-        return post_every(ms, Context1<F,A0>(f,a0));
+    int call_every(int ms, F f, A0 a0) {
+        return call_every(ms, Context1<F,A0>(f,a0));
     }
 
     template <typename F, typename A0, typename A1>
-    int post_every(int ms, F f, A0 a0, A1 a1) {
-        return post_every(ms, Context2<F,A0,A1>(f,a0,a1));
+    int call_every(int ms, F f, A0 a0, A1 a1) {
+        return call_every(ms, Context2<F,A0,A1>(f,a0,a1));
     }
 
     template <typename F, typename A0, typename A1, typename A2>
-    int post_every(int ms, F f, A0 a0, A1 a1, A2 a2) {
-        return post_every(ms, Context3<F,A0,A1,A2>(f,a0,a1,a2));
+    int call_every(int ms, F f, A0 a0, A1 a1, A2 a2) {
+        return call_every(ms, Context3<F,A0,A1,A2>(f,a0,a1,a2));
     }
 
     template <typename F, typename A0, typename A1, typename A2, typename A3>
-    int post_every(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3) {
-        return post_every(ms, Context4<F,A0,A1,A2,A3>(f,a0,a1,a2,a3));
+    int call_every(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3) {
+        return call_every(ms, Context4<F,A0,A1,A2,A3>(f,a0,a1,a2,a3));
     }
 
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
-    int post_every(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-        return post_every(ms, Context5<F,A0,A1,A2,A3,A4>(f,a0,a1,a2,a3,a4));
+    int call_every(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+        return call_every(ms, Context5<F,A0,A1,A2,A3,A4>(f,a0,a1,a2,a3,a4));
     }
 
 protected:

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ int main() {
     EventQueue queue;
 
     // events are simple callbacks
-    queue.post(printf, "called immediately\n");
-    queue.post_in(printf, 2000, "called in 2 seconds\n");
-    queue.post_every(printf, 1000, "called every 1 seconds\n");
+    queue.call(printf, "called immediately\n");
+    queue.call_in(2000, printf, "called in 2 seconds\n");
+    queue.call_every(1000, printf, "called every 1 seconds\n");
 
     // executed by the dispatch method
     queue.dispatch();
@@ -33,7 +33,7 @@ The core API of the events library is contained in the
 EventQueue queue(2048);
 
 // Enqueues events on the underlying event queue
-queue.post(printf, "hi!\n");
+queue.call(printf, "hi!\n");
 
 // The dispatch method acts as the core entry point into the event loop
 // A millisecond timeout can be provided to return from the event loop
@@ -51,40 +51,40 @@ EventLoop loop(osHighPriority);
 loop.start();
 
 // Posting events is thread and irq safe
-loop.post(doit);
+loop.call(doit);
 
 // Stops the event loop cleanly
 loop.stop();
 ```
 
-The EventQueue and EvenLoop classes provide several post functions for
-sending events. The post functions are thread and irq safe and don't need
+The EventQueue and EvenLoop classes provide several call functions for
+sending events. The call functions are thread and irq safe and don't need
 the underlying loop to be running.
 
 ``` cpp
-// Simple post function registers events to be called as soon as possible
-queue.post(doit);
-queue.post(printf, "called immediately\n");
-queue.post(Callback<void(char)>(&serial, &Serial::printf), "hello\n");
+// Simple call function registers events to be called as soon as possible
+queue.call(doit);
+queue.call(printf, "called immediately\n");
+queue.call(Callback<void(char)>(&serial, &Serial::printf), "hello\n");
 
-// The post_in function registers events to be called after a delay
+// The call_in function registers events to be called after a delay
 // specified in milliseconds
-queue.post_in(2000, doit_in_two_seconds);
-queue.post_in(300, printf, "called in 0.3 seconds\n");
+queue.call_in(2000, doit_in_two_seconds);
+queue.call_in(300, printf, "called in 0.3 seconds\n");
 
-// The post_every function registers events to be called repeatedly
+// The call_every function registers events to be called repeatedly
 // with a period specified in milliseconds
-queue.post_every(2000, doit_every_two_seconds);
-queue.post_every(400, printf, "called every 0.4 seconds\n");
+queue.call_every(2000, doit_every_two_seconds);
+queue.call_every(400, printf, "called every 0.4 seconds\n");
 ```
 
-All post calls return an integer id that uniquely represents the event
-on the event queue. The post calls can not block, so 0 is returned if
+All call calls return an integer id that uniquely represents the event
+on the event queue. The call calls can not block, so 0 is returned if
 there is no memory or the queue's event size is exceeded.
 
 ``` cpp
 // The event id is uniqueue to the queue
-int id = queue.post_in(100, printf, "will this work?\n");
+int id = queue.call_in(100, printf, "will this work?\n");
 
 // An id of 0 indicates an error
 if (id) {

--- a/TESTS/events/queue/main.cpp
+++ b/TESTS/events/queue/main.cpp
@@ -46,17 +46,17 @@ void simple_posts_test##i() {                               \
     EventQueue queue;                                       \
                                                             \
     touched = false;                                        \
-    queue.post(func##i,##__VA_ARGS__);                      \
+    queue.call(func##i,##__VA_ARGS__);                      \
     queue.dispatch(0);                                      \
     TEST_ASSERT(touched);                                   \
                                                             \
     touched = false;                                        \
-    queue.post_in(1, func##i,##__VA_ARGS__);                \
+    queue.call_in(1, func##i,##__VA_ARGS__);                \
     queue.dispatch(2);                                      \
     TEST_ASSERT(touched);                                   \
                                                             \
     touched = false;                                        \
-    queue.post_every(1, func##i,##__VA_ARGS__);             \
+    queue.call_every(1, func##i,##__VA_ARGS__);             \
     queue.dispatch(2);                                      \
     TEST_ASSERT(touched);                                   \
 }
@@ -75,28 +75,28 @@ void time_func(Timer *t, int ms) {
 }
 
 template <int N>
-void post_in_test() {
+void call_in_test() {
     Timer tickers[N];
 
     EventQueue queue;
 
     for (int i = 0; i < N; i++) {
         tickers[i].start();
-        queue.post_in((i+1)*100, time_func, &tickers[i], (i+1)*100);
+        queue.call_in((i+1)*100, time_func, &tickers[i], (i+1)*100);
     }
 
     queue.dispatch(N*100);
 }
 
 template <int N>
-void post_every_test() {
+void call_every_test() {
     Timer tickers[N];
 
     EventQueue queue;
 
     for (int i = 0; i < N; i++) {
         tickers[i].start();
-        queue.post_every((i+1)*100, time_func, &tickers[i], (i+1)*100);
+        queue.call_every((i+1)*100, time_func, &tickers[i], (i+1)*100);
     }
 
     queue.dispatch(N*100);
@@ -109,7 +109,7 @@ void event_loop_test1() {
     TEST_ASSERT_EQUAL(osOK, status);
 
     touched = false;
-    loop.post(func0);
+    loop.call(func0);
     Thread::yield();
     TEST_ASSERT(touched);
 
@@ -127,7 +127,7 @@ void event_loop_test2() {
 
     for (int i = 0; i < N; i++) {
         tickers[i].start();
-        loop.post_every((i+1)*100, time_func, &tickers[i], (i+1)*100);
+        loop.call_every((i+1)*100, time_func, &tickers[i], (i+1)*100);
         Thread::yield();
         wait_ms(75);
     }
@@ -140,7 +140,7 @@ struct big { char data[4096]; } big;
 
 void allocate_failure_test1() {
     EventQueue queue;
-    int id = queue.post((void (*)(struct big))0, big);
+    int id = queue.call((void (*)(struct big))0, big);
     TEST_ASSERT(!id);
 }
 
@@ -149,7 +149,7 @@ void allocate_failure_test2() {
     int id;
 
     for (int i = 0; i < 100; i++) {
-        id = queue.post((void (*)())0);
+        id = queue.call((void (*)())0);
     }
 
     TEST_ASSERT(!id);
@@ -166,7 +166,7 @@ void cancel_test1() {
     int ids[N];
 
     for (int i = 0; i < N; i++) {
-        ids[i] = queue.post_in(1000, no);
+        ids[i] = queue.call_in(1000, no);
     }
 
     for (int i = N-1; i >= 0; i--) {
@@ -186,7 +186,7 @@ void cancel_test2() {
     int ids[N];
 
     for (int i = 0; i < N; i++) {
-        ids[i] = loop.post_in(1000, no);
+        ids[i] = loop.call_in(1000, no);
     }
 
     for (int i = N-1; i >= 0; i--) {
@@ -206,15 +206,15 @@ utest::v1::status_t test_setup(const size_t number_of_cases) {
 }
 
 const Case cases[] = {
-    Case("Testing posts with 5 args", simple_posts_test5),
-    Case("Testing posts with 4 args", simple_posts_test4),
-    Case("Testing posts with 3 args", simple_posts_test3),
-    Case("Testing posts with 2 args", simple_posts_test2),
-    Case("Testing posts with 1 args", simple_posts_test1),
-    Case("Testing posts with 0 args", simple_posts_test0),
+    Case("Testing calls with 5 args", simple_posts_test5),
+    Case("Testing calls with 4 args", simple_posts_test4),
+    Case("Testing calls with 3 args", simple_posts_test3),
+    Case("Testing calls with 2 args", simple_posts_test2),
+    Case("Testing calls with 1 args", simple_posts_test1),
+    Case("Testing calls with 0 args", simple_posts_test0),
 
-    Case("Testing post_in",    post_in_test<20>),
-    Case("Testing post_every", post_every_test<20>),
+    Case("Testing call_in",    call_in_test<20>),
+    Case("Testing call_every", call_every_test<20>),
 
 #ifdef MBED_CONF_RTOS_PRESENT
     Case("Testing event loop 1", event_loop_test1),


### PR DESCRIPTION
Rename post -> call functions:

```
post       -> call
post_in    -> call_in
post_every -> call_every
```
- Matches names of underlying C api
- Allows option of moving C api's post function into C++ api
- In my opinion, may be more intuitive

@kilogram, @pan-, thoughts?
