### PR TITLE
Rename events.h -> mbed_events.h to avoid potential name collisions

### DIFF
--- a/EventLoop.cpp
+++ b/EventLoop.cpp
@@ -1,7 +1,7 @@
 #ifdef MBED_CONF_RTOS_PRESENT
 #include "EventLoop.h"
 
-#include "events.h"
+#include "mbed_events.h"
 #include "rtos.h"
 #include "mbed.h"
 

--- a/EventQueue.cpp
+++ b/EventQueue.cpp
@@ -1,6 +1,6 @@
 #include "EventQueue.h"
 
-#include "events.h"
+#include "mbed_events.h"
 #include "mbed.h"
 
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The events library provides a flexible event queue for scheduling events.
 
 ``` cpp
-#include "events.h"
+#include "mbed_events.h"
 #include <stdio.h>
 
 int main() {

--- a/TESTS/events/queue/main.cpp
+++ b/TESTS/events/queue/main.cpp
@@ -1,4 +1,4 @@
-#include "events.h"
+#include "mbed_events.h"
 #include "mbed.h"
 #include "rtos.h"
 #include "greentea-client/test_env.h"

--- a/mbed_events.h
+++ b/mbed_events.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef EVENTS_CPP_H
-#define EVENTS_CPP_H
+#ifndef MBED_EVENTS_H
+#define MBED_EVENTS_H
 
 
 #include "events-c/events.h"


### PR DESCRIPTION
Note from @pan-:

> Headers in this library should be prefixed otherwise they can easily clash with over headers.
> For instance events.h is too generic and can be taken by other libraries. 

The events.h name may be a common name for header files. On faulty build systems, there is a potential for this common name to cause the wrong header file to be included.

discussion https://github.com/ARMmbed/mbed-events/issues/6
cc @pan-, @0xc0170 
fixes #6
