### PR TITLE
Fixed compilation error on Cortex A platforms

### DIFF
--- a/events-c/events_mbed.cpp
+++ b/events-c/events_mbed.cpp
@@ -52,12 +52,11 @@ int events_mutex_create(events_mutex_t *m) { return 0; }
 void events_mutex_destroy(events_mutex_t *m) { }
 
 void events_mutex_lock(events_mutex_t *m) {
-    *m = __get_PRIMASK();
-    __disable_irq();
+    core_util_critical_section_enter();
 }
 
 void events_mutex_unlock(events_mutex_t *m) {
-    __set_PRIMASK(*m);
+    core_util_critical_section_exit();
 }
 
 


### PR DESCRIPTION
Before, __get_PRIMASK/__set_PRIMASK were used directly to manipulate the state of interrupts. These are only available on Cortex M platforms.

Adopted core_util_critical_section_enter/exit from mbed critical.h, which provides this behaviour in a cross-platform manner.

This should fix #11 
