### PR TITLE
Add the Event class for fine-grain control of event dispatch

### DIFF
--- a/Event.h
+++ b/Event.h
@@ -41,6 +41,7 @@ public:
      *  callback acts as the target for the event and is executed in the
      *  context of the event queue's dispatch loop once posted.
      *
+     *  @param q        Event queue to dispatch on
      *  @param f        Function to execute when the event is dispatched
      *  @param a0..a4   Arguments to pass to the callback
      */
@@ -1180,6 +1181,36 @@ private:
     } *_event;
 };
 
+
+template <typename F>
+Event<> EventQueue::event(F f) {
+    return Event<>(this, f);
+}
+
+template <typename F, typename A0>
+Event<> EventQueue::event(F f, A0 a0) {
+    return Event<>(this, f, a0);
+}
+
+template <typename F, typename A0, typename A1>
+Event<> EventQueue::event(F f, A0 a0, A1 a1) {
+    return Event<>(this, f, a0, a1);
+}
+
+template <typename F, typename A0, typename A1, typename A2>
+Event<> EventQueue::event(F f, A0 a0, A1 a1, A2 a2) {
+    return Event<>(this, f, a0, a1, a2);
+}
+
+template <typename F, typename A0, typename A1, typename A2, typename A3>
+Event<> EventQueue::event(F f, A0 a0, A1 a1, A2 a2, A3 a3) {
+    return Event<>(this, f, a0, a1, a2, a3);
+}
+
+template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<> EventQueue::event(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+    return Event<>(this, f, a0, a1, a2, a3, a4);
+}
 
 }
 

--- a/Event.h
+++ b/Event.h
@@ -1,0 +1,1186 @@
+/* events
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef EVENT_H
+#define EVENT_H
+
+#include "EventQueue.h"
+#include "mbed_assert.h"
+
+namespace events {
+
+/** Event
+ *
+ *  Representation of an event for fine-grain dispatch control
+ */
+template <typename A0=void, typename A1=void, typename A2=void, typename A3=void, typename A4=void>
+class Event;
+
+/** Event
+ *
+ *  Representation of an event for fine-grain dispatch control
+ */
+template <>
+class Event<> {
+public:
+    /** Event lifetime
+     *
+     *  Constructs an event bound to the specified event queue. The specified
+     *  callback acts as the target for the event and is executed in the
+     *  context of the event queue's dispatch loop once posted.
+     *
+     *  @param f        Function to execute when the event is dispatched
+     *  @param a0..a4   Arguments to pass to the callback
+     */
+    template <typename F>
+    Event(EventQueue *q, F f) {
+        struct local {
+            static int post(struct event *e) {
+                typedef EventQueue::context00<F> C;
+                struct local {
+                    static void call(void *p) { (*static_cast<C*>(p))(); }
+                    static void dtor(void *p) { static_cast<C*>(p)->~C(); }
+                };
+
+                void *p = equeue_alloc(e->equeue, sizeof(C));
+                if (!p) {
+                    return 0;
+                }
+
+                new (p) C(*reinterpret_cast<F*>(e+1));
+                equeue_event_delay(p, e->delay);
+                equeue_event_period(p, e->period);
+                equeue_event_dtor(p, &local::dtor);
+                return equeue_post(e->equeue, &local::call, p);
+            }
+
+            static void dtor(struct event *e) {
+                reinterpret_cast<F*>(e+1)->~F();
+            }
+        };
+
+        _event = static_cast<struct event *>(
+                equeue_alloc(&q->_equeue, sizeof(struct event) + sizeof(F)));
+        if (_event) {
+            _event->equeue = &q->_equeue;
+            _event->id = 0;
+            _event->delay = 0;
+            _event->period = -1;
+
+            _event->post = &local::post;
+            _event->dtor = &local::dtor;
+
+            new (_event+1) F(f);
+
+            _event->ref = 1;
+        }
+    }
+
+    template <typename F, typename B0>
+    Event(EventQueue *q, F f, B0 b0) {
+        new (this) Event(q, EventQueue::
+                context10<F, B0>(f, b0));
+    }
+
+    template <typename F, typename B0, typename B1>
+    Event(EventQueue *q, F f, B0 b0, B1 b1) {
+        new (this) Event(q, EventQueue::
+                context20<F, B0, B1>(f, b0, b1));
+    }
+
+    template <typename F, typename B0, typename B1, typename B2>
+    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2) {
+        new (this) Event(q, EventQueue::
+                context30<F, B0, B1, B2>(f, b0, b1, b2));
+    }
+
+    template <typename F, typename B0, typename B1, typename B2, typename B3>
+    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3) {
+        new (this) Event(q, EventQueue::
+                context40<F, B0, B1, B2, B3>(f, b0, b1, b2, b3));
+    }
+
+    template <typename F, typename B0, typename B1, typename B2, typename B3, typename B4>
+    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
+        new (this) Event(q, EventQueue::
+                context50<F, B0, B1, B2, B3, B4>(f, b0, b1, b2, b3, b4));
+    }
+
+    Event(const Event &e) {
+        _event = 0;
+        if (e._event) {
+            _event = e._event;
+            _event->ref += 1;
+        }
+    }
+
+    Event &operator=(const Event &that) {
+        if (this != &that) {
+            this->~Event();
+            new (this) Event(that);
+        }
+
+        return *this;
+    }
+
+    ~Event() {
+        if (_event) {
+            _event->ref -= 1;
+            if (_event->ref == 0) {
+                _event->dtor(_event);
+                equeue_dealloc(_event->equeue, _event);
+            }
+        }
+    }
+
+    /** Configure the delay of an event
+     *
+     *  @param delay    Millisecond delay before dispatching the event
+     */
+    void delay(int delay) {
+        if (_event) {
+            _event->delay = delay;
+        }
+    }
+
+    /** Configure the period of an event
+     *
+     *  @param period   Millisecond period for repeatedly dispatching an event
+     */
+    void period(int period) {
+        if (_event) {
+            _event->period = period;
+        }
+    }
+
+    /** Posts an event onto the underlying event queue
+     *
+     *  The event is posted to the underlying queue and is executed in the
+     *  context of the event queue's dispatch loop.
+     *
+     *  The post function is irq safe and can act as a mechanism for moving
+     *  events out of irq contexts.
+     *
+     *  @param a0..a4   Arguments to pass to the event
+     *  @return         A unique id that represents the posted event and can
+     *                  be passed to EventQueue::cancel, or an id of 0 if
+     *                  there is not enough memory to allocate the event.
+     */
+    int post() {
+        if (!_event) {
+            return 0;
+        }
+
+        _event->id = _event->post(_event);
+        return _event->id;
+    }
+
+    /** Cancels the most recently posted event
+     *
+     *  Attempts to cancel the most recently posted event. It is safe to call
+     *  cancel after an event has already been dispatched.
+     *
+     *  The cancel function is irq safe.
+     *
+     *  If called while the event queue's dispatch loop is active, the cancel
+     *  function does not garuntee that the event will not execute after it
+     *  returns, as the event may have already begun executing.
+     */
+    void cancel() {
+        if (_event) {
+            equeue_cancel(_event->equeue, _event->id);
+        }
+    }
+
+private:
+    struct event {
+        unsigned ref;
+        equeue_t *equeue;
+        int id;
+
+        int delay;
+        int period;
+
+        int (*post)(struct event *);
+        void (*dtor)(struct event *);
+
+        // F follows
+    } *_event;
+};
+
+/** Event
+ *
+ *  Representation of an event for fine-grain dispatch control
+ */
+template <typename A0>
+class Event<A0> {
+public:
+    /** Event lifetime
+     *
+     *  Constructs an event bound to the specified event queue. The specified
+     *  callback acts as the target for the event and is executed in the
+     *  context of the event queue's dispatch loop once posted.
+     *
+     *  @param f        Function to execute when the event is dispatched
+     *  @param a0..a4   Arguments to pass to the callback
+     */
+    template <typename F>
+    Event(EventQueue *q, F f) {
+        struct local {
+            static int post(struct event *e, A0 a0) {
+                typedef EventQueue::context10<F, A0> C;
+                struct local {
+                    static void call(void *p) { (*static_cast<C*>(p))(); }
+                    static void dtor(void *p) { static_cast<C*>(p)->~C(); }
+                };
+
+                void *p = equeue_alloc(e->equeue, sizeof(C));
+                if (!p) {
+                    return 0;
+                }
+
+                new (p) C(*reinterpret_cast<F*>(e+1), a0);
+                equeue_event_delay(p, e->delay);
+                equeue_event_period(p, e->period);
+                equeue_event_dtor(p, &local::dtor);
+                return equeue_post(e->equeue, &local::call, p);
+            }
+
+            static void dtor(struct event *e) {
+                reinterpret_cast<F*>(e+1)->~F();
+            }
+        };
+
+        _event = static_cast<struct event *>(
+                equeue_alloc(&q->_equeue, sizeof(struct event) + sizeof(F)));
+        if (_event) {
+            _event->equeue = &q->_equeue;
+            _event->id = 0;
+            _event->delay = 0;
+            _event->period = -1;
+
+            _event->post = &local::post;
+            _event->dtor = &local::dtor;
+
+            new (_event+1) F(f);
+
+            _event->ref = 1;
+        }
+    }
+
+    template <typename F, typename B0>
+    Event(EventQueue *q, F f, B0 b0) {
+        new (this) Event(q, EventQueue::
+                context11<F, B0, A0>(f, b0));
+    }
+
+    template <typename F, typename B0, typename B1>
+    Event(EventQueue *q, F f, B0 b0, B1 b1) {
+        new (this) Event(q, EventQueue::
+                context21<F, B0, B1, A0>(f, b0, b1));
+    }
+
+    template <typename F, typename B0, typename B1, typename B2>
+    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2) {
+        new (this) Event(q, EventQueue::
+                context31<F, B0, B1, B2, A0>(f, b0, b1, b2));
+    }
+
+    template <typename F, typename B0, typename B1, typename B2, typename B3>
+    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3) {
+        new (this) Event(q, EventQueue::
+                context41<F, B0, B1, B2, B3, A0>(f, b0, b1, b2, b3));
+    }
+
+    template <typename F, typename B0, typename B1, typename B2, typename B3, typename B4>
+    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
+        new (this) Event(q, EventQueue::
+                context51<F, B0, B1, B2, B3, B4, A0>(f, b0, b1, b2, b3, b4));
+    }
+
+    Event(const Event &e) {
+        _event = 0;
+        if (e._event) {
+            _event = e._event;
+            _event->ref += 1;
+        }
+    }
+
+    Event &operator=(const Event &that) {
+        if (this != &that) {
+            this->~Event();
+            new (this) Event(that);
+        }
+
+        return *this;
+    }
+
+    ~Event() {
+        if (_event) {
+            _event->ref -= 1;
+            if (_event->ref == 0) {
+                _event->dtor(_event);
+                equeue_dealloc(_event->equeue, _event);
+            }
+        }
+    }
+
+    /** Configure the delay of an event
+     *
+     *  @param delay    Millisecond delay before dispatching the event
+     */
+    void delay(int delay) {
+        if (_event) {
+            _event->delay = delay;
+        }
+    }
+
+    /** Configure the period of an event
+     *
+     *  @param period   Millisecond period for repeatedly dispatching an event
+     */
+    void period(int period) {
+        if (_event) {
+            _event->period = period;
+        }
+    }
+
+    /** Posts an event onto the underlying event queue
+     *
+     *  The event is posted to the underlying queue and is executed in the
+     *  context of the event queue's dispatch loop.
+     *
+     *  The post function is irq safe and can act as a mechanism for moving
+     *  events out of irq contexts.
+     *
+     *  @param a0..a4   Arguments to pass to the event
+     *  @return         A unique id that represents the posted event and can
+     *                  be passed to EventQueue::cancel, or an id of 0 if
+     *                  there is not enough memory to allocate the event.
+     */
+    int post(A0 a0) {
+        if (!_event) {
+            return 0;
+        }
+
+        _event->id = _event->post(_event, a0);
+        return _event->id;
+    }
+
+    /** Cancels the most recently posted event
+     *
+     *  Attempts to cancel the most recently posted event. It is safe to call
+     *  cancel after an event has already been dispatched.
+     *
+     *  The cancel function is irq safe.
+     *
+     *  If called while the event queue's dispatch loop is active, the cancel
+     *  function does not garuntee that the event will not execute after it
+     *  returns, as the event may have already begun executing.
+     */
+    void cancel() {
+        if (_event) {
+            equeue_cancel(_event->equeue, _event->id);
+        }
+    }
+
+private:
+    struct event {
+        unsigned ref;
+        equeue_t *equeue;
+        int id;
+
+        int delay;
+        int period;
+
+        int (*post)(struct event *, A0 a0);
+        void (*dtor)(struct event *);
+
+        // F follows
+    } *_event;
+};
+
+/** Event
+ *
+ *  Representation of an event for fine-grain dispatch control
+ */
+template <typename A0, typename A1>
+class Event<A0, A1> {
+public:
+    /** Event lifetime
+     *
+     *  Constructs an event bound to the specified event queue. The specified
+     *  callback acts as the target for the event and is executed in the
+     *  context of the event queue's dispatch loop once posted.
+     *
+     *  @param f        Function to execute when the event is dispatched
+     *  @param a0..a4   Arguments to pass to the callback
+     */
+    template <typename F>
+    Event(EventQueue *q, F f) {
+        struct local {
+            static int post(struct event *e, A0 a0, A1 a1) {
+                typedef EventQueue::context20<F, A0, A1> C;
+                struct local {
+                    static void call(void *p) { (*static_cast<C*>(p))(); }
+                    static void dtor(void *p) { static_cast<C*>(p)->~C(); }
+                };
+
+                void *p = equeue_alloc(e->equeue, sizeof(C));
+                if (!p) {
+                    return 0;
+                }
+
+                new (p) C(*reinterpret_cast<F*>(e+1), a0, a1);
+                equeue_event_delay(p, e->delay);
+                equeue_event_period(p, e->period);
+                equeue_event_dtor(p, &local::dtor);
+                return equeue_post(e->equeue, &local::call, p);
+            }
+
+            static void dtor(struct event *e) {
+                reinterpret_cast<F*>(e+1)->~F();
+            }
+        };
+
+        _event = static_cast<struct event *>(
+                equeue_alloc(&q->_equeue, sizeof(struct event) + sizeof(F)));
+        if (_event) {
+            _event->equeue = &q->_equeue;
+            _event->id = 0;
+            _event->delay = 0;
+            _event->period = -1;
+
+            _event->post = &local::post;
+            _event->dtor = &local::dtor;
+
+            new (_event+1) F(f);
+
+            _event->ref = 1;
+        }
+    }
+
+    template <typename F, typename B0>
+    Event(EventQueue *q, F f, B0 b0) {
+        new (this) Event(q, EventQueue::
+                context12<F, B0, A0, A1>(f, b0));
+    }
+
+    template <typename F, typename B0, typename B1>
+    Event(EventQueue *q, F f, B0 b0, B1 b1) {
+        new (this) Event(q, EventQueue::
+                context22<F, B0, B1, A0, A1>(f, b0, b1));
+    }
+
+    template <typename F, typename B0, typename B1, typename B2>
+    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2) {
+        new (this) Event(q, EventQueue::
+                context32<F, B0, B1, B2, A0, A1>(f, b0, b1, b2));
+    }
+
+    template <typename F, typename B0, typename B1, typename B2, typename B3>
+    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3) {
+        new (this) Event(q, EventQueue::
+                context42<F, B0, B1, B2, B3, A0, A1>(f, b0, b1, b2, b3));
+    }
+
+    template <typename F, typename B0, typename B1, typename B2, typename B3, typename B4>
+    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
+        new (this) Event(q, EventQueue::
+                context52<F, B0, B1, B2, B3, B4, A0, A1>(f, b0, b1, b2, b3, b4));
+    }
+
+    Event(const Event &e) {
+        _event = 0;
+        if (e._event) {
+            _event = e._event;
+            _event->ref += 1;
+        }
+    }
+
+    Event &operator=(const Event &that) {
+        if (this != &that) {
+            this->~Event();
+            new (this) Event(that);
+        }
+
+        return *this;
+    }
+
+    ~Event() {
+        if (_event) {
+            _event->ref -= 1;
+            if (_event->ref == 0) {
+                _event->dtor(_event);
+                equeue_dealloc(_event->equeue, _event);
+            }
+        }
+    }
+
+    /** Configure the delay of an event
+     *
+     *  @param delay    Millisecond delay before dispatching the event
+     */
+    void delay(int delay) {
+        if (_event) {
+            _event->delay = delay;
+        }
+    }
+
+    /** Configure the period of an event
+     *
+     *  @param period   Millisecond period for repeatedly dispatching an event
+     */
+    void period(int period) {
+        if (_event) {
+            _event->period = period;
+        }
+    }
+
+    /** Posts an event onto the underlying event queue
+     *
+     *  The event is posted to the underlying queue and is executed in the
+     *  context of the event queue's dispatch loop.
+     *
+     *  The post function is irq safe and can act as a mechanism for moving
+     *  events out of irq contexts.
+     *
+     *  @param a0..a4   Arguments to pass to the event
+     *  @return         A unique id that represents the posted event and can
+     *                  be passed to EventQueue::cancel, or an id of 0 if
+     *                  there is not enough memory to allocate the event.
+     */
+    int post(A0 a0, A1 a1) {
+        if (!_event) {
+            return 0;
+        }
+
+        _event->id = _event->post(_event, a0, a1);
+        return _event->id;
+    }
+
+    /** Cancels the most recently posted event
+     *
+     *  Attempts to cancel the most recently posted event. It is safe to call
+     *  cancel after an event has already been dispatched.
+     *
+     *  The cancel function is irq safe.
+     *
+     *  If called while the event queue's dispatch loop is active, the cancel
+     *  function does not garuntee that the event will not execute after it
+     *  returns, as the event may have already begun executing.
+     */
+    void cancel() {
+        if (_event) {
+            equeue_cancel(_event->equeue, _event->id);
+        }
+    }
+
+private:
+    struct event {
+        unsigned ref;
+        equeue_t *equeue;
+        int id;
+
+        int delay;
+        int period;
+
+        int (*post)(struct event *, A0 a0, A1 a1);
+        void (*dtor)(struct event *);
+
+        // F follows
+    } *_event;
+};
+
+/** Event
+ *
+ *  Representation of an event for fine-grain dispatch control
+ */
+template <typename A0, typename A1, typename A2>
+class Event<A0, A1, A2> {
+public:
+    /** Event lifetime
+     *
+     *  Constructs an event bound to the specified event queue. The specified
+     *  callback acts as the target for the event and is executed in the
+     *  context of the event queue's dispatch loop once posted.
+     *
+     *  @param f        Function to execute when the event is dispatched
+     *  @param a0..a4   Arguments to pass to the callback
+     */
+    template <typename F>
+    Event(EventQueue *q, F f) {
+        struct local {
+            static int post(struct event *e, A0 a0, A1 a1, A2 a2) {
+                typedef EventQueue::context30<F, A0, A1, A2> C;
+                struct local {
+                    static void call(void *p) { (*static_cast<C*>(p))(); }
+                    static void dtor(void *p) { static_cast<C*>(p)->~C(); }
+                };
+
+                void *p = equeue_alloc(e->equeue, sizeof(C));
+                if (!p) {
+                    return 0;
+                }
+
+                new (p) C(*reinterpret_cast<F*>(e+1), a0, a1, a2);
+                equeue_event_delay(p, e->delay);
+                equeue_event_period(p, e->period);
+                equeue_event_dtor(p, &local::dtor);
+                return equeue_post(e->equeue, &local::call, p);
+            }
+
+            static void dtor(struct event *e) {
+                reinterpret_cast<F*>(e+1)->~F();
+            }
+        };
+
+        _event = static_cast<struct event *>(
+                equeue_alloc(&q->_equeue, sizeof(struct event) + sizeof(F)));
+        if (_event) {
+            _event->equeue = &q->_equeue;
+            _event->id = 0;
+            _event->delay = 0;
+            _event->period = -1;
+
+            _event->post = &local::post;
+            _event->dtor = &local::dtor;
+
+            new (_event+1) F(f);
+
+            _event->ref = 1;
+        }
+    }
+
+    template <typename F, typename B0>
+    Event(EventQueue *q, F f, B0 b0) {
+        new (this) Event(q, EventQueue::
+                context13<F, B0, A0, A1, A2>(f, b0));
+    }
+
+    template <typename F, typename B0, typename B1>
+    Event(EventQueue *q, F f, B0 b0, B1 b1) {
+        new (this) Event(q, EventQueue::
+                context23<F, B0, B1, A0, A1, A2>(f, b0, b1));
+    }
+
+    template <typename F, typename B0, typename B1, typename B2>
+    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2) {
+        new (this) Event(q, EventQueue::
+                context33<F, B0, B1, B2, A0, A1, A2>(f, b0, b1, b2));
+    }
+
+    template <typename F, typename B0, typename B1, typename B2, typename B3>
+    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3) {
+        new (this) Event(q, EventQueue::
+                context43<F, B0, B1, B2, B3, A0, A1, A2>(f, b0, b1, b2, b3));
+    }
+
+    template <typename F, typename B0, typename B1, typename B2, typename B3, typename B4>
+    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
+        new (this) Event(q, EventQueue::
+                context53<F, B0, B1, B2, B3, B4, A0, A1, A2>(f, b0, b1, b2, b3, b4));
+    }
+
+    Event(const Event &e) {
+        _event = 0;
+        if (e._event) {
+            _event = e._event;
+            _event->ref += 1;
+        }
+    }
+
+    Event &operator=(const Event &that) {
+        if (this != &that) {
+            this->~Event();
+            new (this) Event(that);
+        }
+
+        return *this;
+    }
+
+    ~Event() {
+        if (_event) {
+            _event->ref -= 1;
+            if (_event->ref == 0) {
+                _event->dtor(_event);
+                equeue_dealloc(_event->equeue, _event);
+            }
+        }
+    }
+
+    /** Configure the delay of an event
+     *
+     *  @param delay    Millisecond delay before dispatching the event
+     */
+    void delay(int delay) {
+        if (_event) {
+            _event->delay = delay;
+        }
+    }
+
+    /** Configure the period of an event
+     *
+     *  @param period   Millisecond period for repeatedly dispatching an event
+     */
+    void period(int period) {
+        if (_event) {
+            _event->period = period;
+        }
+    }
+
+    /** Posts an event onto the underlying event queue
+     *
+     *  The event is posted to the underlying queue and is executed in the
+     *  context of the event queue's dispatch loop.
+     *
+     *  The post function is irq safe and can act as a mechanism for moving
+     *  events out of irq contexts.
+     *
+     *  @param a0..a4   Arguments to pass to the event
+     *  @return         A unique id that represents the posted event and can
+     *                  be passed to EventQueue::cancel, or an id of 0 if
+     *                  there is not enough memory to allocate the event.
+     */
+    int post(A0 a0, A1 a1, A2 a2) {
+        if (!_event) {
+            return 0;
+        }
+
+        _event->id = _event->post(_event, a0, a1, a2);
+        return _event->id;
+    }
+
+    /** Cancels the most recently posted event
+     *
+     *  Attempts to cancel the most recently posted event. It is safe to call
+     *  cancel after an event has already been dispatched.
+     *
+     *  The cancel function is irq safe.
+     *
+     *  If called while the event queue's dispatch loop is active, the cancel
+     *  function does not garuntee that the event will not execute after it
+     *  returns, as the event may have already begun executing.
+     */
+    void cancel() {
+        if (_event) {
+            equeue_cancel(_event->equeue, _event->id);
+        }
+    }
+
+private:
+    struct event {
+        unsigned ref;
+        equeue_t *equeue;
+        int id;
+
+        int delay;
+        int period;
+
+        int (*post)(struct event *, A0 a0, A1 a1, A2 a2);
+        void (*dtor)(struct event *);
+
+        // F follows
+    } *_event;
+};
+
+/** Event
+ *
+ *  Representation of an event for fine-grain dispatch control
+ */
+template <typename A0, typename A1, typename A2, typename A3>
+class Event<A0, A1, A2, A3> {
+public:
+    /** Event lifetime
+     *
+     *  Constructs an event bound to the specified event queue. The specified
+     *  callback acts as the target for the event and is executed in the
+     *  context of the event queue's dispatch loop once posted.
+     *
+     *  @param f        Function to execute when the event is dispatched
+     *  @param a0..a4   Arguments to pass to the callback
+     */
+    template <typename F>
+    Event(EventQueue *q, F f) {
+        struct local {
+            static int post(struct event *e, A0 a0, A1 a1, A2 a2, A3 a3) {
+                typedef EventQueue::context40<F, A0, A1, A2, A3> C;
+                struct local {
+                    static void call(void *p) { (*static_cast<C*>(p))(); }
+                    static void dtor(void *p) { static_cast<C*>(p)->~C(); }
+                };
+
+                void *p = equeue_alloc(e->equeue, sizeof(C));
+                if (!p) {
+                    return 0;
+                }
+
+                new (p) C(*reinterpret_cast<F*>(e+1), a0, a1, a2, a3);
+                equeue_event_delay(p, e->delay);
+                equeue_event_period(p, e->period);
+                equeue_event_dtor(p, &local::dtor);
+                return equeue_post(e->equeue, &local::call, p);
+            }
+
+            static void dtor(struct event *e) {
+                reinterpret_cast<F*>(e+1)->~F();
+            }
+        };
+
+        _event = static_cast<struct event *>(
+                equeue_alloc(&q->_equeue, sizeof(struct event) + sizeof(F)));
+        if (_event) {
+            _event->equeue = &q->_equeue;
+            _event->id = 0;
+            _event->delay = 0;
+            _event->period = -1;
+
+            _event->post = &local::post;
+            _event->dtor = &local::dtor;
+
+            new (_event+1) F(f);
+
+            _event->ref = 1;
+        }
+    }
+
+    template <typename F, typename B0>
+    Event(EventQueue *q, F f, B0 b0) {
+        new (this) Event(q, EventQueue::
+                context14<F, B0, A0, A1, A2, A3>(f, b0));
+    }
+
+    template <typename F, typename B0, typename B1>
+    Event(EventQueue *q, F f, B0 b0, B1 b1) {
+        new (this) Event(q, EventQueue::
+                context24<F, B0, B1, A0, A1, A2, A3>(f, b0, b1));
+    }
+
+    template <typename F, typename B0, typename B1, typename B2>
+    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2) {
+        new (this) Event(q, EventQueue::
+                context34<F, B0, B1, B2, A0, A1, A2, A3>(f, b0, b1, b2));
+    }
+
+    template <typename F, typename B0, typename B1, typename B2, typename B3>
+    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3) {
+        new (this) Event(q, EventQueue::
+                context44<F, B0, B1, B2, B3, A0, A1, A2, A3>(f, b0, b1, b2, b3));
+    }
+
+    template <typename F, typename B0, typename B1, typename B2, typename B3, typename B4>
+    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
+        new (this) Event(q, EventQueue::
+                context54<F, B0, B1, B2, B3, B4, A0, A1, A2, A3>(f, b0, b1, b2, b3, b4));
+    }
+
+    Event(const Event &e) {
+        _event = 0;
+        if (e._event) {
+            _event = e._event;
+            _event->ref += 1;
+        }
+    }
+
+    Event &operator=(const Event &that) {
+        if (this != &that) {
+            this->~Event();
+            new (this) Event(that);
+        }
+
+        return *this;
+    }
+
+    ~Event() {
+        if (_event) {
+            _event->ref -= 1;
+            if (_event->ref == 0) {
+                _event->dtor(_event);
+                equeue_dealloc(_event->equeue, _event);
+            }
+        }
+    }
+
+    /** Configure the delay of an event
+     *
+     *  @param delay    Millisecond delay before dispatching the event
+     */
+    void delay(int delay) {
+        if (_event) {
+            _event->delay = delay;
+        }
+    }
+
+    /** Configure the period of an event
+     *
+     *  @param period   Millisecond period for repeatedly dispatching an event
+     */
+    void period(int period) {
+        if (_event) {
+            _event->period = period;
+        }
+    }
+
+    /** Posts an event onto the underlying event queue
+     *
+     *  The event is posted to the underlying queue and is executed in the
+     *  context of the event queue's dispatch loop.
+     *
+     *  The post function is irq safe and can act as a mechanism for moving
+     *  events out of irq contexts.
+     *
+     *  @param a0..a4   Arguments to pass to the event
+     *  @return         A unique id that represents the posted event and can
+     *                  be passed to EventQueue::cancel, or an id of 0 if
+     *                  there is not enough memory to allocate the event.
+     */
+    int post(A0 a0, A1 a1, A2 a2, A3 a3) {
+        if (!_event) {
+            return 0;
+        }
+
+        _event->id = _event->post(_event, a0, a1, a2, a3);
+        return _event->id;
+    }
+
+    /** Cancels the most recently posted event
+     *
+     *  Attempts to cancel the most recently posted event. It is safe to call
+     *  cancel after an event has already been dispatched.
+     *
+     *  The cancel function is irq safe.
+     *
+     *  If called while the event queue's dispatch loop is active, the cancel
+     *  function does not garuntee that the event will not execute after it
+     *  returns, as the event may have already begun executing.
+     */
+    void cancel() {
+        if (_event) {
+            equeue_cancel(_event->equeue, _event->id);
+        }
+    }
+
+private:
+    struct event {
+        unsigned ref;
+        equeue_t *equeue;
+        int id;
+
+        int delay;
+        int period;
+
+        int (*post)(struct event *, A0 a0, A1 a1, A2 a2, A3 a3);
+        void (*dtor)(struct event *);
+
+        // F follows
+    } *_event;
+};
+
+/** Event
+ *
+ *  Representation of an event for fine-grain dispatch control
+ */
+template <typename A0, typename A1, typename A2, typename A3, typename A4>
+class Event {
+public:
+    /** Event lifetime
+     *
+     *  Constructs an event bound to the specified event queue. The specified
+     *  callback acts as the target for the event and is executed in the
+     *  context of the event queue's dispatch loop once posted.
+     *
+     *  @param f        Function to execute when the event is dispatched
+     *  @param a0..a4   Arguments to pass to the callback
+     */
+    template <typename F>
+    Event(EventQueue *q, F f) {
+        struct local {
+            static int post(struct event *e, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+                typedef EventQueue::context50<F, A0, A1, A2, A3, A4> C;
+                struct local {
+                    static void call(void *p) { (*static_cast<C*>(p))(); }
+                    static void dtor(void *p) { static_cast<C*>(p)->~C(); }
+                };
+
+                void *p = equeue_alloc(e->equeue, sizeof(C));
+                if (!p) {
+                    return 0;
+                }
+
+                new (p) C(*reinterpret_cast<F*>(e+1), a0, a1, a2, a3, a4);
+                equeue_event_delay(p, e->delay);
+                equeue_event_period(p, e->period);
+                equeue_event_dtor(p, &local::dtor);
+                return equeue_post(e->equeue, &local::call, p);
+            }
+
+            static void dtor(struct event *e) {
+                reinterpret_cast<F*>(e+1)->~F();
+            }
+        };
+
+        _event = static_cast<struct event *>(
+                equeue_alloc(&q->_equeue, sizeof(struct event) + sizeof(F)));
+        if (_event) {
+            _event->equeue = &q->_equeue;
+            _event->id = 0;
+            _event->delay = 0;
+            _event->period = -1;
+
+            _event->post = &local::post;
+            _event->dtor = &local::dtor;
+
+            new (_event+1) F(f);
+
+            _event->ref = 1;
+        }
+    }
+
+    template <typename F, typename B0>
+    Event(EventQueue *q, F f, B0 b0) {
+        new (this) Event(q, EventQueue::
+                context15<F, B0, A0, A1, A2, A3, A4>(f, b0));
+    }
+
+    template <typename F, typename B0, typename B1>
+    Event(EventQueue *q, F f, B0 b0, B1 b1) {
+        new (this) Event(q, EventQueue::
+                context25<F, B0, B1, A0, A1, A2, A3, A4>(f, b0, b1));
+    }
+
+    template <typename F, typename B0, typename B1, typename B2>
+    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2) {
+        new (this) Event(q, EventQueue::
+                context35<F, B0, B1, B2, A0, A1, A2, A3, A4>(f, b0, b1, b2));
+    }
+
+    template <typename F, typename B0, typename B1, typename B2, typename B3>
+    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3) {
+        new (this) Event(q, EventQueue::
+                context45<F, B0, B1, B2, B3, A0, A1, A2, A3, A4>(f, b0, b1, b2, b3));
+    }
+
+    template <typename F, typename B0, typename B1, typename B2, typename B3, typename B4>
+    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
+        new (this) Event(q, EventQueue::
+                context55<F, B0, B1, B2, B3, B4, A0, A1, A2, A3, A4>(f, b0, b1, b2, b3, b4));
+    }
+
+    Event(const Event &e) {
+        _event = 0;
+        if (e._event) {
+            _event = e._event;
+            _event->ref += 1;
+        }
+    }
+
+    Event &operator=(const Event &that) {
+        if (this != &that) {
+            this->~Event();
+            new (this) Event(that);
+        }
+
+        return *this;
+    }
+
+    ~Event() {
+        if (_event) {
+            _event->ref -= 1;
+            if (_event->ref == 0) {
+                _event->dtor(_event);
+                equeue_dealloc(_event->equeue, _event);
+            }
+        }
+    }
+
+    /** Configure the delay of an event
+     *
+     *  @param delay    Millisecond delay before dispatching the event
+     */
+    void delay(int delay) {
+        if (_event) {
+            _event->delay = delay;
+        }
+    }
+
+    /** Configure the period of an event
+     *
+     *  @param period   Millisecond period for repeatedly dispatching an event
+     */
+    void period(int period) {
+        if (_event) {
+            _event->period = period;
+        }
+    }
+
+    /** Posts an event onto the underlying event queue
+     *
+     *  The event is posted to the underlying queue and is executed in the
+     *  context of the event queue's dispatch loop.
+     *
+     *  The post function is irq safe and can act as a mechanism for moving
+     *  events out of irq contexts.
+     *
+     *  @param a0..a4   Arguments to pass to the event
+     *  @return         A unique id that represents the posted event and can
+     *                  be passed to EventQueue::cancel, or an id of 0 if
+     *                  there is not enough memory to allocate the event.
+     */
+    int post(A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+        if (!_event) {
+            return 0;
+        }
+
+        _event->id = _event->post(_event, a0, a1, a2, a3, a4);
+        return _event->id;
+    }
+
+    /** Cancels the most recently posted event
+     *
+     *  Attempts to cancel the most recently posted event. It is safe to call
+     *  cancel after an event has already been dispatched.
+     *
+     *  The cancel function is irq safe.
+     *
+     *  If called while the event queue's dispatch loop is active, the cancel
+     *  function does not garuntee that the event will not execute after it
+     *  returns, as the event may have already begun executing.
+     */
+    void cancel() {
+        if (_event) {
+            equeue_cancel(_event->equeue, _event->id);
+        }
+    }
+
+private:
+    struct event {
+        unsigned ref;
+        equeue_t *equeue;
+        int id;
+
+        int delay;
+        int period;
+
+        int (*post)(struct event *, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4);
+        void (*dtor)(struct event *);
+
+        // F follows
+    } *_event;
+};
+
+
+}
+
+#endif

--- a/Event.h
+++ b/Event.h
@@ -25,7 +25,7 @@ namespace events {
  *
  *  Representation of an event for fine-grain dispatch control
  */
-template <typename A0=void, typename A1=void, typename A2=void, typename A3=void, typename A4=void>
+template <typename F>
 class Event;
 
 /** Event
@@ -33,7 +33,7 @@ class Event;
  *  Representation of an event for fine-grain dispatch control
  */
 template <>
-class Event<> {
+class Event<void()> {
 public:
     /** Event lifetime
      *
@@ -226,7 +226,7 @@ private:
  *  Representation of an event for fine-grain dispatch control
  */
 template <typename A0>
-class Event<A0> {
+class Event<void(A0)> {
 public:
     /** Event lifetime
      *
@@ -234,6 +234,7 @@ public:
      *  callback acts as the target for the event and is executed in the
      *  context of the event queue's dispatch loop once posted.
      *
+     *  @param q        Event queue to dispatch on
      *  @param f        Function to execute when the event is dispatched
      *  @param a0..a4   Arguments to pass to the callback
      */
@@ -418,7 +419,7 @@ private:
  *  Representation of an event for fine-grain dispatch control
  */
 template <typename A0, typename A1>
-class Event<A0, A1> {
+class Event<void(A0, A1)> {
 public:
     /** Event lifetime
      *
@@ -426,6 +427,7 @@ public:
      *  callback acts as the target for the event and is executed in the
      *  context of the event queue's dispatch loop once posted.
      *
+     *  @param q        Event queue to dispatch on
      *  @param f        Function to execute when the event is dispatched
      *  @param a0..a4   Arguments to pass to the callback
      */
@@ -610,7 +612,7 @@ private:
  *  Representation of an event for fine-grain dispatch control
  */
 template <typename A0, typename A1, typename A2>
-class Event<A0, A1, A2> {
+class Event<void(A0, A1, A2)> {
 public:
     /** Event lifetime
      *
@@ -618,6 +620,7 @@ public:
      *  callback acts as the target for the event and is executed in the
      *  context of the event queue's dispatch loop once posted.
      *
+     *  @param q        Event queue to dispatch on
      *  @param f        Function to execute when the event is dispatched
      *  @param a0..a4   Arguments to pass to the callback
      */
@@ -802,7 +805,7 @@ private:
  *  Representation of an event for fine-grain dispatch control
  */
 template <typename A0, typename A1, typename A2, typename A3>
-class Event<A0, A1, A2, A3> {
+class Event<void(A0, A1, A2, A3)> {
 public:
     /** Event lifetime
      *
@@ -810,6 +813,7 @@ public:
      *  callback acts as the target for the event and is executed in the
      *  context of the event queue's dispatch loop once posted.
      *
+     *  @param q        Event queue to dispatch on
      *  @param f        Function to execute when the event is dispatched
      *  @param a0..a4   Arguments to pass to the callback
      */
@@ -994,7 +998,7 @@ private:
  *  Representation of an event for fine-grain dispatch control
  */
 template <typename A0, typename A1, typename A2, typename A3, typename A4>
-class Event {
+class Event<void(A0, A1, A2, A3, A4)> {
 public:
     /** Event lifetime
      *
@@ -1002,6 +1006,7 @@ public:
      *  callback acts as the target for the event and is executed in the
      *  context of the event queue's dispatch loop once posted.
      *
+     *  @param q        Event queue to dispatch on
      *  @param f        Function to execute when the event is dispatched
      *  @param a0..a4   Arguments to pass to the callback
      */
@@ -1183,33 +1188,33 @@ private:
 
 
 template <typename F>
-Event<> EventQueue::event(F f) {
-    return Event<>(this, f);
+Event<void()> EventQueue::event(F f) {
+    return Event<void()>(this, f);
 }
 
 template <typename F, typename A0>
-Event<> EventQueue::event(F f, A0 a0) {
-    return Event<>(this, f, a0);
+Event<void()> EventQueue::event(F f, A0 a0) {
+    return Event<void()>(this, f, a0);
 }
 
 template <typename F, typename A0, typename A1>
-Event<> EventQueue::event(F f, A0 a0, A1 a1) {
-    return Event<>(this, f, a0, a1);
+Event<void()> EventQueue::event(F f, A0 a0, A1 a1) {
+    return Event<void()>(this, f, a0, a1);
 }
 
 template <typename F, typename A0, typename A1, typename A2>
-Event<> EventQueue::event(F f, A0 a0, A1 a1, A2 a2) {
-    return Event<>(this, f, a0, a1, a2);
+Event<void()> EventQueue::event(F f, A0 a0, A1 a1, A2 a2) {
+    return Event<void()>(this, f, a0, a1, a2);
 }
 
 template <typename F, typename A0, typename A1, typename A2, typename A3>
-Event<> EventQueue::event(F f, A0 a0, A1 a1, A2 a2, A3 a3) {
-    return Event<>(this, f, a0, a1, a2, a3);
+Event<void()> EventQueue::event(F f, A0 a0, A1 a1, A2 a2, A3 a3) {
+    return Event<void()>(this, f, a0, a1, a2, a3);
 }
 
 template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<> EventQueue::event(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-    return Event<>(this, f, a0, a1, a2, a3, a4);
+Event<void()> EventQueue::event(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+    return Event<void()>(this, f, a0, a1, a2, a3, a4);
 }
 
 }

--- a/EventQueue.h
+++ b/EventQueue.h
@@ -37,7 +37,7 @@ namespace events {
 #define EVENTS_QUEUE_SIZE (32*EVENTS_EVENT_SIZE)
 
 // Predeclared classes
-template <typename A0, typename A1, typename A2, typename A3, typename A4>
+template <typename F>
 class Event;
 
 
@@ -329,31 +329,25 @@ public:
      *  @return         Event that will dispatch on the specific queue
      */
     template <typename F>
-    Event<void, void, void, void, void>
-    event(F f);
+    Event<void()> event(F f);
 
     template <typename F, typename A0>
-    Event<void, void, void, void, void>
-    event(F f, A0 a0);
+    Event<void()> event(F f, A0 a0);
 
     template <typename F, typename A0, typename A1>
-    Event<void, void, void, void, void>
-    event(F f, A0 a0, A1 a1);
+    Event<void()> event(F f, A0 a0, A1 a1);
 
     template <typename F, typename A0, typename A1, typename A2>
-    Event<void, void, void, void, void>
-    event(F f, A0 a0, A1 a1, A2 a2);
+    Event<void()> event(F f, A0 a0, A1 a1, A2 a2);
 
     template <typename F, typename A0, typename A1, typename A2, typename A3>
-    Event<void, void, void, void, void>
-    event(F f, A0 a0, A1 a1, A2 a2, A3 a3);
+    Event<void()> event(F f, A0 a0, A1 a1, A2 a2, A3 a3);
 
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void, void, void, void, void>
-    event(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4);
+    Event<void()> event(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4);
 
 protected:
-    template <typename A0, typename A1, typename A2, typename A3, typename A4>
+    template <typename F>
     friend class Event;
     struct equeue _equeue;
     mbed::Callback<void(int)> _update;

--- a/EventQueue.h
+++ b/EventQueue.h
@@ -36,6 +36,10 @@ namespace events {
  */
 #define EVENTS_QUEUE_SIZE (32*EVENTS_EVENT_SIZE)
 
+// Predeclared classes
+template <typename A0, typename A1, typename A2, typename A3, typename A4>
+class Event;
+
 
 /** EventQueue
  *
@@ -313,6 +317,40 @@ public:
     int call_every(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
         return call_every(ms, context50<F, A0, A1, A2, A3, A4>(f, a0, a1, a2, a3, a4));
     }
+
+    /** Event creation
+     *
+     *  Constructs an event bound to the specified event queue. The specified
+     *  callback acts as the target for the event and is executed in the
+     *  context of the event queue's dispatch loop once posted.
+     *
+     *  @param f        Function to execute when the event is dispatched
+     *  @param a0..a4   Arguments to pass to the callback
+     *  @return         Event that will dispatch on the specific queue
+     */
+    template <typename F>
+    Event<void, void, void, void, void>
+    event(F f);
+
+    template <typename F, typename A0>
+    Event<void, void, void, void, void>
+    event(F f, A0 a0);
+
+    template <typename F, typename A0, typename A1>
+    Event<void, void, void, void, void>
+    event(F f, A0 a0, A1 a1);
+
+    template <typename F, typename A0, typename A1, typename A2>
+    Event<void, void, void, void, void>
+    event(F f, A0 a0, A1 a1, A2 a2);
+
+    template <typename F, typename A0, typename A1, typename A2, typename A3>
+    Event<void, void, void, void, void>
+    event(F f, A0 a0, A1 a1, A2 a2, A3 a3);
+
+    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void, void, void, void, void>
+    event(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4);
 
 protected:
     template <typename A0, typename A1, typename A2, typename A3, typename A4>
@@ -717,6 +755,15 @@ protected:
     };
 };
 
+}
+
+
+// Include event class here to workaround cyclic dependencies
+// between Event and EventQueue
+//#include "Event.h"
+
+
+namespace events {
 
 }
 

--- a/EventQueue.h
+++ b/EventQueue.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #ifndef EVENT_QUEUE_H
 #define EVENT_QUEUE_H
 
@@ -22,7 +23,6 @@
 #include <new>
 
 namespace events {
-
 
 /** EVENTS_EVENT_SIZE
  *  Minimum size of an event
@@ -157,39 +157,44 @@ public:
      */
     template <typename F>
     int call(F f) {
+        struct local {
+            static void call(void *p) { (*static_cast<F*>(p))(); }
+            static void dtor(void *p) { static_cast<F*>(p)->~F(); }
+        };
+
         void *p = equeue_alloc(&_equeue, sizeof(F));
         if (!p) {
             return 0;
         }
 
         F *e = new (p) F(f);
-        equeue_event_dtor(e, &EventQueue::dtor<F>);
-        return equeue_post(&_equeue, &EventQueue::call<F>, e);
+        equeue_event_dtor(e, &local::dtor);
+        return equeue_post(&_equeue, &local::call, e);
     }
 
     template <typename F, typename A0>
     int call(F f, A0 a0) {
-        return call(Context1<F,A0>(f,a0));
+        return call(context10<F, A0>(f, a0));
     }
 
     template <typename F, typename A0, typename A1>
     int call(F f, A0 a0, A1 a1) {
-        return call(Context2<F,A0,A1>(f,a0,a1));
+        return call(context20<F, A0, A1>(f, a0, a1));
     }
 
     template <typename F, typename A0, typename A1, typename A2>
     int call(F f, A0 a0, A1 a1, A2 a2) {
-        return call(Context3<F,A0,A1,A2>(f,a0,a1,a2));
+        return call(context30<F, A0, A1, A2>(f, a0, a1, a2));
     }
 
     template <typename F, typename A0, typename A1, typename A2, typename A3>
     int call(F f, A0 a0, A1 a1, A2 a2, A3 a3) {
-        return call(Context4<F,A0,A1,A2,A3>(f,a0,a1,a2,a3));
+        return call(context40<F, A0, A1, A2, A3>(f, a0, a1, a2, a3));
     }
 
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
     int call(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-        return call(Context5<F,A0,A1,A2,A3,A4>(f,a0,a1,a2,a3,a4));
+        return call(context50<F, A0, A1, A2, A3, A4>(f, a0, a1, a2, a3, a4));
     }
 
     /** Post an event to the queue after a specified delay
@@ -209,6 +214,11 @@ public:
      */
     template <typename F>
     int call_in(int ms, F f) {
+        struct local {
+            static void call(void *p) { (*static_cast<F*>(p))(); }
+            static void dtor(void *p) { static_cast<F*>(p)->~F(); }
+        };
+
         void *p = equeue_alloc(&_equeue, sizeof(F));
         if (!p) {
             return 0;
@@ -216,33 +226,33 @@ public:
 
         F *e = new (p) F(f);
         equeue_event_delay(e, ms);
-        equeue_event_dtor(e, &EventQueue::dtor<F>);
-        return equeue_post(&_equeue, &EventQueue::call<F>, e);
+        equeue_event_dtor(e, &local::dtor);
+        return equeue_post(&_equeue, &local::call, e);
     }
 
     template <typename F, typename A0>
     int call_in(int ms, F f, A0 a0) {
-        return call_in(ms, Context1<F,A0>(f,a0));
+        return call_in(ms, context10<F, A0>(f, a0));
     }
 
     template <typename F, typename A0, typename A1>
     int call_in(int ms, F f, A0 a0, A1 a1) {
-        return call_in(ms, Context2<F,A0,A1>(f,a0,a1));
+        return call_in(ms, context20<F, A0, A1>(f, a0, a1));
     }
 
     template <typename F, typename A0, typename A1, typename A2>
     int call_in(int ms, F f, A0 a0, A1 a1, A2 a2) {
-        return call_in(ms, Context3<F,A0,A1,A2>(f,a0,a1,a2));
+        return call_in(ms, context30<F, A0, A1, A2>(f, a0, a1, a2));
     }
 
     template <typename F, typename A0, typename A1, typename A2, typename A3>
     int call_in(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3) {
-        return call_in(ms, Context4<F,A0,A1,A2,A3>(f,a0,a1,a2,a3));
+        return call_in(ms, context40<F, A0, A1, A2, A3>(f, a0, a1, a2, a3));
     }
 
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
     int call_in(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-        return call_in(ms, Context5<F,A0,A1,A2,A3,A4>(f,a0,a1,a2,a3,a4));
+        return call_in(ms, context50<F, A0, A1, A2, A3, A4>(f, a0, a1, a2, a3, a4));
     }
 
     /** Post an event to the queue periodically
@@ -262,6 +272,11 @@ public:
      */
     template <typename F>
     int call_every(int ms, F f) {
+        struct local {
+            static void call(void *p) { (*static_cast<F*>(p))(); }
+            static void dtor(void *p) { static_cast<F*>(p)->~F(); }
+        };
+
         void *p = equeue_alloc(&_equeue, sizeof(F));
         if (!p) {
             return 0;
@@ -270,92 +285,56 @@ public:
         F *e = new (p) F(f);
         equeue_event_delay(e, ms);
         equeue_event_period(e, ms);
-        equeue_event_dtor(e, &EventQueue::dtor<F>);
-        return equeue_post(&_equeue, &EventQueue::call<F>, e);
+        equeue_event_dtor(e, &local::dtor);
+        return equeue_post(&_equeue, &local::call, e);
     }
 
     template <typename F, typename A0>
     int call_every(int ms, F f, A0 a0) {
-        return call_every(ms, Context1<F,A0>(f,a0));
+        return call_every(ms, context10<F, A0>(f, a0));
     }
 
     template <typename F, typename A0, typename A1>
     int call_every(int ms, F f, A0 a0, A1 a1) {
-        return call_every(ms, Context2<F,A0,A1>(f,a0,a1));
+        return call_every(ms, context20<F, A0, A1>(f, a0, a1));
     }
 
     template <typename F, typename A0, typename A1, typename A2>
     int call_every(int ms, F f, A0 a0, A1 a1, A2 a2) {
-        return call_every(ms, Context3<F,A0,A1,A2>(f,a0,a1,a2));
+        return call_every(ms, context30<F, A0, A1, A2>(f, a0, a1, a2));
     }
 
     template <typename F, typename A0, typename A1, typename A2, typename A3>
     int call_every(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3) {
-        return call_every(ms, Context4<F,A0,A1,A2,A3>(f,a0,a1,a2,a3));
+        return call_every(ms, context40<F, A0, A1, A2, A3>(f, a0, a1, a2, a3));
     }
 
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
     int call_every(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-        return call_every(ms, Context5<F,A0,A1,A2,A3,A4>(f,a0,a1,a2,a3,a4));
+        return call_every(ms, context50<F, A0, A1, A2, A3, A4>(f, a0, a1, a2, a3, a4));
     }
 
 protected:
+    template <typename A0, typename A1, typename A2, typename A3, typename A4>
+    friend class Event;
     struct equeue _equeue;
     mbed::Callback<void(int)> _update;
 
-    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
-    struct Context5 {
-        F f; A0 a0; A1 a1; A2 a2; A3 a3; A4 a4;
-
-        Context5(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
-            : f(f), a0(a0), a1(a1), a2(a2), a3(a3), a4(a4) {}
-
-        void operator()() {
-            f(a0, a1, a2, a3, a4);
-        }
-    };
-
-    template <typename F, typename A0, typename A1, typename A2, typename A3>
-    struct Context4 {
-        F f; A0 a0; A1 a1; A2 a2; A3 a3;
-
-        Context4(F f, A0 a0, A1 a1, A2 a2, A3 a3)
-            : f(f), a0(a0), a1(a1), a2(a2), a3(a3) {}
+    template <typename F>
+    struct context00 {
+        F f;
+        context00(F f)
+            : f(f) {}
 
         void operator()() {
-            f(a0, a1, a2, a3);
-        }
-    };
-
-    template <typename F, typename A0, typename A1, typename A2>
-    struct Context3 {
-        F f; A0 a0; A1 a1; A2 a2;
-
-        Context3(F f, A0 a0, A1 a1, A2 a2)
-            : f(f), a0(a0), a1(a1), a2(a2) {}
-
-        void operator()() {
-            f(a0, a1, a2);
-        }
-    };
-
-    template <typename F, typename A0, typename A1>
-    struct Context2 {
-        F f; A0 a0; A1 a1;
-
-        Context2(F f, A0 a0, A1 a1)
-            : f(f), a0(a0), a1(a1) {}
-
-        void operator()() {
-            f(a0, a1);
+            f();
         }
     };
 
     template <typename F, typename A0>
-    struct Context1 {
+    struct context10 {
         F f; A0 a0;
-
-        Context1(F f, A0 a0)
+        context10(F f, A0 a0)
             : f(f), a0(a0) {}
 
         void operator()() {
@@ -363,15 +342,379 @@ protected:
         }
     };
 
-    template <typename T>
-    static void call(void *p) {
-        (*static_cast<T*>(p))();
-    }
+    template <typename F, typename A0, typename A1>
+    struct context20 {
+        F f; A0 a0; A1 a1;
+        context20(F f, A0 a0, A1 a1)
+            : f(f), a0(a0), a1(a1) {}
 
-    template <typename T>
-    static void dtor(void *p) {
-        static_cast<T*>(p)->~T();
-    }
+        void operator()() {
+            f(a0, a1);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename A2>
+    struct context30 {
+        F f; A0 a0; A1 a1; A2 a2;
+        context30(F f, A0 a0, A1 a1, A2 a2)
+            : f(f), a0(a0), a1(a1), a2(a2) {}
+
+        void operator()() {
+            f(a0, a1, a2);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename A2, typename A3>
+    struct context40 {
+        F f; A0 a0; A1 a1; A2 a2; A3 a3;
+        context40(F f, A0 a0, A1 a1, A2 a2, A3 a3)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3) {}
+
+        void operator()() {
+            f(a0, a1, a2, a3);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
+    struct context50 {
+        F f; A0 a0; A1 a1; A2 a2; A3 a3; A4 a4;
+        context50(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3), a4(a4) {}
+
+        void operator()() {
+            f(a0, a1, a2, a3, a4);
+        }
+    };
+
+    template <typename F, typename B0>
+    struct context01 {
+        F f;
+        context01(F f)
+            : f(f) {}
+
+        void operator()(B0 b0) {
+            f(b0);
+        }
+    };
+
+    template <typename F, typename A0, typename B0>
+    struct context11 {
+        F f; A0 a0;
+        context11(F f, A0 a0)
+            : f(f), a0(a0) {}
+
+        void operator()(B0 b0) {
+            f(a0, b0);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename B0>
+    struct context21 {
+        F f; A0 a0; A1 a1;
+        context21(F f, A0 a0, A1 a1)
+            : f(f), a0(a0), a1(a1) {}
+
+        void operator()(B0 b0) {
+            f(a0, a1, b0);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename A2, typename B0>
+    struct context31 {
+        F f; A0 a0; A1 a1; A2 a2;
+        context31(F f, A0 a0, A1 a1, A2 a2)
+            : f(f), a0(a0), a1(a1), a2(a2) {}
+
+        void operator()(B0 b0) {
+            f(a0, a1, a2, b0);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename A2, typename A3, typename B0>
+    struct context41 {
+        F f; A0 a0; A1 a1; A2 a2; A3 a3;
+        context41(F f, A0 a0, A1 a1, A2 a2, A3 a3)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3) {}
+
+        void operator()(B0 b0) {
+            f(a0, a1, a2, a3, b0);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4, typename B0>
+    struct context51 {
+        F f; A0 a0; A1 a1; A2 a2; A3 a3; A4 a4;
+        context51(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3), a4(a4) {}
+
+        void operator()(B0 b0) {
+            f(a0, a1, a2, a3, a4, b0);
+        }
+    };
+
+    template <typename F, typename B0, typename B1>
+    struct context02 {
+        F f;
+        context02(F f)
+            : f(f) {}
+
+        void operator()(B0 b0, B1 b1) {
+            f(b0, b1);
+        }
+    };
+
+    template <typename F, typename A0, typename B0, typename B1>
+    struct context12 {
+        F f; A0 a0;
+        context12(F f, A0 a0)
+            : f(f), a0(a0) {}
+
+        void operator()(B0 b0, B1 b1) {
+            f(a0, b0, b1);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename B0, typename B1>
+    struct context22 {
+        F f; A0 a0; A1 a1;
+        context22(F f, A0 a0, A1 a1)
+            : f(f), a0(a0), a1(a1) {}
+
+        void operator()(B0 b0, B1 b1) {
+            f(a0, a1, b0, b1);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename A2, typename B0, typename B1>
+    struct context32 {
+        F f; A0 a0; A1 a1; A2 a2;
+        context32(F f, A0 a0, A1 a1, A2 a2)
+            : f(f), a0(a0), a1(a1), a2(a2) {}
+
+        void operator()(B0 b0, B1 b1) {
+            f(a0, a1, a2, b0, b1);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename A2, typename A3, typename B0, typename B1>
+    struct context42 {
+        F f; A0 a0; A1 a1; A2 a2; A3 a3;
+        context42(F f, A0 a0, A1 a1, A2 a2, A3 a3)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3) {}
+
+        void operator()(B0 b0, B1 b1) {
+            f(a0, a1, a2, a3, b0, b1);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4, typename B0, typename B1>
+    struct context52 {
+        F f; A0 a0; A1 a1; A2 a2; A3 a3; A4 a4;
+        context52(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3), a4(a4) {}
+
+        void operator()(B0 b0, B1 b1) {
+            f(a0, a1, a2, a3, a4, b0, b1);
+        }
+    };
+
+    template <typename F, typename B0, typename B1, typename B2>
+    struct context03 {
+        F f;
+        context03(F f)
+            : f(f) {}
+
+        void operator()(B0 b0, B1 b1, B2 b2) {
+            f(b0, b1, b2);
+        }
+    };
+
+    template <typename F, typename A0, typename B0, typename B1, typename B2>
+    struct context13 {
+        F f; A0 a0;
+        context13(F f, A0 a0)
+            : f(f), a0(a0) {}
+
+        void operator()(B0 b0, B1 b1, B2 b2) {
+            f(a0, b0, b1, b2);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename B0, typename B1, typename B2>
+    struct context23 {
+        F f; A0 a0; A1 a1;
+        context23(F f, A0 a0, A1 a1)
+            : f(f), a0(a0), a1(a1) {}
+
+        void operator()(B0 b0, B1 b1, B2 b2) {
+            f(a0, a1, b0, b1, b2);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename A2, typename B0, typename B1, typename B2>
+    struct context33 {
+        F f; A0 a0; A1 a1; A2 a2;
+        context33(F f, A0 a0, A1 a1, A2 a2)
+            : f(f), a0(a0), a1(a1), a2(a2) {}
+
+        void operator()(B0 b0, B1 b1, B2 b2) {
+            f(a0, a1, a2, b0, b1, b2);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename A2, typename A3, typename B0, typename B1, typename B2>
+    struct context43 {
+        F f; A0 a0; A1 a1; A2 a2; A3 a3;
+        context43(F f, A0 a0, A1 a1, A2 a2, A3 a3)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3) {}
+
+        void operator()(B0 b0, B1 b1, B2 b2) {
+            f(a0, a1, a2, a3, b0, b1, b2);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4, typename B0, typename B1, typename B2>
+    struct context53 {
+        F f; A0 a0; A1 a1; A2 a2; A3 a3; A4 a4;
+        context53(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3), a4(a4) {}
+
+        void operator()(B0 b0, B1 b1, B2 b2) {
+            f(a0, a1, a2, a3, a4, b0, b1, b2);
+        }
+    };
+
+    template <typename F, typename B0, typename B1, typename B2, typename B3>
+    struct context04 {
+        F f;
+        context04(F f)
+            : f(f) {}
+
+        void operator()(B0 b0, B1 b1, B2 b2, B3 b3) {
+            f(b0, b1, b2, b3);
+        }
+    };
+
+    template <typename F, typename A0, typename B0, typename B1, typename B2, typename B3>
+    struct context14 {
+        F f; A0 a0;
+        context14(F f, A0 a0)
+            : f(f), a0(a0) {}
+
+        void operator()(B0 b0, B1 b1, B2 b2, B3 b3) {
+            f(a0, b0, b1, b2, b3);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename B0, typename B1, typename B2, typename B3>
+    struct context24 {
+        F f; A0 a0; A1 a1;
+        context24(F f, A0 a0, A1 a1)
+            : f(f), a0(a0), a1(a1) {}
+
+        void operator()(B0 b0, B1 b1, B2 b2, B3 b3) {
+            f(a0, a1, b0, b1, b2, b3);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename A2, typename B0, typename B1, typename B2, typename B3>
+    struct context34 {
+        F f; A0 a0; A1 a1; A2 a2;
+        context34(F f, A0 a0, A1 a1, A2 a2)
+            : f(f), a0(a0), a1(a1), a2(a2) {}
+
+        void operator()(B0 b0, B1 b1, B2 b2, B3 b3) {
+            f(a0, a1, a2, b0, b1, b2, b3);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename A2, typename A3, typename B0, typename B1, typename B2, typename B3>
+    struct context44 {
+        F f; A0 a0; A1 a1; A2 a2; A3 a3;
+        context44(F f, A0 a0, A1 a1, A2 a2, A3 a3)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3) {}
+
+        void operator()(B0 b0, B1 b1, B2 b2, B3 b3) {
+            f(a0, a1, a2, a3, b0, b1, b2, b3);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4, typename B0, typename B1, typename B2, typename B3>
+    struct context54 {
+        F f; A0 a0; A1 a1; A2 a2; A3 a3; A4 a4;
+        context54(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3), a4(a4) {}
+
+        void operator()(B0 b0, B1 b1, B2 b2, B3 b3) {
+            f(a0, a1, a2, a3, a4, b0, b1, b2, b3);
+        }
+    };
+
+    template <typename F, typename B0, typename B1, typename B2, typename B3, typename B4>
+    struct context05 {
+        F f;
+        context05(F f)
+            : f(f) {}
+
+        void operator()(B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
+            f(b0, b1, b2, b3, b4);
+        }
+    };
+
+    template <typename F, typename A0, typename B0, typename B1, typename B2, typename B3, typename B4>
+    struct context15 {
+        F f; A0 a0;
+        context15(F f, A0 a0)
+            : f(f), a0(a0) {}
+
+        void operator()(B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
+            f(a0, b0, b1, b2, b3, b4);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename B0, typename B1, typename B2, typename B3, typename B4>
+    struct context25 {
+        F f; A0 a0; A1 a1;
+        context25(F f, A0 a0, A1 a1)
+            : f(f), a0(a0), a1(a1) {}
+
+        void operator()(B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
+            f(a0, a1, b0, b1, b2, b3, b4);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename A2, typename B0, typename B1, typename B2, typename B3, typename B4>
+    struct context35 {
+        F f; A0 a0; A1 a1; A2 a2;
+        context35(F f, A0 a0, A1 a1, A2 a2)
+            : f(f), a0(a0), a1(a1), a2(a2) {}
+
+        void operator()(B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
+            f(a0, a1, a2, b0, b1, b2, b3, b4);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename A2, typename A3, typename B0, typename B1, typename B2, typename B3, typename B4>
+    struct context45 {
+        F f; A0 a0; A1 a1; A2 a2; A3 a3;
+        context45(F f, A0 a0, A1 a1, A2 a2, A3 a3)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3) {}
+
+        void operator()(B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
+            f(a0, a1, a2, a3, b0, b1, b2, b3, b4);
+        }
+    };
+
+    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4, typename B0, typename B1, typename B2, typename B3, typename B4>
+    struct context55 {
+        F f; A0 a0; A1 a1; A2 a2; A3 a3; A4 a4;
+        context55(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3), a4(a4) {}
+
+        void operator()(B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
+            f(a0, a1, a2, a3, a4, b0, b1, b2, b3, b4);
+        }
+    };
 };
 
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ expect a callback.
 ``` cpp
 // Creates an event bound to the specified event queue
 EventQueue queue;
-Event<> event(&queue, doit);
+Event<void()> event(&queue, doit);
 
 // The event can be manually configured for special timing requirements
 // specified in milliseconds
@@ -113,7 +113,7 @@ queue.dispatch();
 
 // Events can also pass arguments to the underlying callback when both
 // initially constructed and posted.
-Event<int, int> event(&queue, printf, "recieved %d and %d\n");
+Event<void(int, int)> event(&queue, printf, "recieved %d and %d\n");
 
 // Events can be posted multiple times and enqueue gracefully until
 // the dispatch function is called.

--- a/README.md
+++ b/README.md
@@ -92,8 +92,40 @@ if (id) {
 queue.cancel(id);
 ```
 
-Event queuest easily align with module boundaries, where internal state can
-be implicitely synchronized through event dispatch. Multiple modules can
+For a more fine-grain control of event dispatch, the `Event` class can be
+manually instantiated and configured. An `Event` represents an event as
+a C++ style function object and can be directly passed to other APIs that
+expect a callback.
+
+``` cpp
+// Creates an event bound to the specified event queue
+EventQueue queue;
+Event<> event(&queue, doit);
+
+// The event can be manually configured for special timing requirements
+// specified in milliseconds
+event.delay(10);
+event.period(10000);
+
+// Posted events are dispatched in the context of the queue's
+// dispatch function
+queue.dispatch();
+
+// Events can also pass arguments to the underlying callback when both
+// initially constructed and posted.
+Event<int, int> event(&queue, printf, "recieved %d and %d\n");
+
+// Events can be posted multiple times and enqueue gracefully until
+// the dispatch function is called.
+event.post(1, 2);
+event.post(3, 4);
+event.post(5, 6);
+
+queue.dispatch();
+```
+
+Event queues easily align with module boundaries, where internal state can
+be implicitly synchronized through event dispatch. Multiple modules can
 use independent event queues, but still be composed through the
 `EventQueue::chain` function.
 
@@ -117,4 +149,5 @@ b.chain(&a);
 // all three queues
 a.dispatch();
 ```
+
 

--- a/TESTS/events/queue/main.cpp
+++ b/TESTS/events/queue/main.cpp
@@ -174,12 +174,12 @@ void event_class_test() {
     counter = 0;
     EventQueue queue(2048);
 
-    Event<int, int, int, int, int> e5(&queue, count5);
-    Event<int, int, int, int> e4(&queue, count5, 1);
-    Event<int, int, int> e3(&queue, count5, 1, 1);
-    Event<int, int> e2(&queue, count5, 1, 1, 1);
-    Event<int> e1(&queue, count5, 1, 1, 1, 1);
-    Event<> e0(&queue, count5, 1, 1, 1, 1, 1);
+    Event<void(int, int, int, int, int)> e5(&queue, count5);
+    Event<void(int, int, int, int)> e4(&queue, count5, 1);
+    Event<void(int, int, int)> e3(&queue, count5, 1, 1);
+    Event<void(int, int)> e2(&queue, count5, 1, 1, 1);
+    Event<void(int)> e1(&queue, count5, 1, 1, 1, 1);
+    Event<void()> e0(&queue, count5, 1, 1, 1, 1, 1);
 
     e5.post(1, 1, 1, 1, 1);
     e4.post(1, 1, 1, 1);
@@ -197,12 +197,12 @@ void event_class_helper_test() {
     counter = 0;
     EventQueue queue(2048);
 
-    Event<> e5 = queue.event(count5, 1, 1, 1, 1, 1);
-    Event<> e4 = queue.event(count4, 1, 1, 1, 1);
-    Event<> e3 = queue.event(count3, 1, 1, 1);
-    Event<> e2 = queue.event(count2, 1, 1);
-    Event<> e1 = queue.event(count1, 1);
-    Event<> e0 = queue.event(count0);
+    Event<void()> e5 = queue.event(count5, 1, 1, 1, 1, 1);
+    Event<void()> e4 = queue.event(count4, 1, 1, 1, 1);
+    Event<void()> e3 = queue.event(count3, 1, 1, 1);
+    Event<void()> e2 = queue.event(count2, 1, 1);
+    Event<void()> e1 = queue.event(count1, 1);
+    Event<void()> e0 = queue.event(count0);
 
     e5.post();
     e4.post();

--- a/TESTS/events/queue/main.cpp
+++ b/TESTS/events/queue/main.cpp
@@ -143,6 +143,36 @@ void cancel_test1() {
 }
 
 
+// Testing the dynamic arguments to the event class
+unsigned counter = 0;
+
+void count5(unsigned a0, unsigned a1, unsigned a2, unsigned a3, unsigned a5) {
+    counter += a0 + a1 + a2 + a3 + a5;
+}
+
+void event_class_test() {
+    EventQueue queue(2048);
+
+    Event<int, int, int, int, int> e5(&queue, count5);
+    Event<int, int, int, int> e4(&queue, count5, 1);
+    Event<int, int, int> e3(&queue, count5, 1, 1);
+    Event<int, int> e2(&queue, count5, 1, 1, 1);
+    Event<int> e1(&queue, count5, 1, 1, 1, 1);
+    Event<> e0(&queue, count5, 1, 1, 1, 1, 1);
+
+    e5.post(1, 1, 1, 1, 1);
+    e4.post(1, 1, 1, 1);
+    e3.post(1, 1, 1);
+    e2.post(1, 1);
+    e1.post(1);
+    e0.post();
+
+    queue.dispatch(0);
+
+    TEST_ASSERT_EQUAL(counter, 30);
+}
+
+
 // Test setup
 utest::v1::status_t test_setup(const size_t number_of_cases) {
     GREENTEA_SETUP(20, "default_auto");
@@ -164,6 +194,7 @@ const Case cases[] = {
     Case("Testing allocate failure 2", allocate_failure_test2),
 
     Case("Testing event cancel 1", cancel_test1<20>),
+    Case("Testing the event class", event_class_test),
 };
 
 Specification specification(test_setup, cases);

--- a/TESTS/events/queue/main.cpp
+++ b/TESTS/events/queue/main.cpp
@@ -150,7 +150,28 @@ void count5(unsigned a0, unsigned a1, unsigned a2, unsigned a3, unsigned a5) {
     counter += a0 + a1 + a2 + a3 + a5;
 }
 
+void count4(unsigned a0, unsigned a1, unsigned a2, unsigned a3) {
+    counter += a0 + a1 + a2 + a3;
+}
+
+void count3(unsigned a0, unsigned a1, unsigned a2) {
+    counter += a0 + a1 + a2;
+}
+
+void count2(unsigned a0, unsigned a1) {
+    counter += a0 + a1;
+}
+
+void count1(unsigned a0) {
+    counter += a0;
+}
+
+void count0() {
+    counter += 0;
+}
+
 void event_class_test() {
+    counter = 0;
     EventQueue queue(2048);
 
     Event<int, int, int, int, int> e5(&queue, count5);
@@ -170,6 +191,29 @@ void event_class_test() {
     queue.dispatch(0);
 
     TEST_ASSERT_EQUAL(counter, 30);
+}
+
+void event_class_helper_test() {
+    counter = 0;
+    EventQueue queue(2048);
+
+    Event<> e5 = queue.event(count5, 1, 1, 1, 1, 1);
+    Event<> e4 = queue.event(count4, 1, 1, 1, 1);
+    Event<> e3 = queue.event(count3, 1, 1, 1);
+    Event<> e2 = queue.event(count2, 1, 1);
+    Event<> e1 = queue.event(count1, 1);
+    Event<> e0 = queue.event(count0);
+
+    e5.post();
+    e4.post();
+    e3.post();
+    e2.post();
+    e1.post();
+    e0.post();
+
+    queue.dispatch(0);
+
+    TEST_ASSERT_EQUAL(counter, 15);
 }
 
 
@@ -195,6 +239,7 @@ const Case cases[] = {
 
     Case("Testing event cancel 1", cancel_test1<20>),
     Case("Testing the event class", event_class_test),
+    Case("Testing the event class helpers", event_class_helper_test),
 };
 
 Specification specification(test_setup, cases);

--- a/mbed_events.h
+++ b/mbed_events.h
@@ -23,6 +23,7 @@
 #ifdef __cplusplus
 
 #include "EventQueue.h"
+#include "Event.h"
 
 using namespace events;
 


### PR DESCRIPTION
For a more fine-grain control of event dispatch, the Event class can be manually instantiated and configured. An `Event` represents an event as a C++ style function object and can be directly passed
to other APIs that expect a callback.

From the updated readme:

``` cpp
// Creates an event bound to the specified event queue
EventQueue queue;
Event<void()> event(&queue, doit);

// The event can be manually configured for special timing requirements
// specified in milliseconds
event.delay(10);
event.period(10000);

// Posted events are dispatched in the constext of the queue's
// dispatch function
queue.dispatch();

// Events can also pass arguments to the underlying callback when both
// initially constructed and posted.
Event<void(int, int)> event(&queue, printf, "recieved %d and %d\n");

// Events can be posted multiple times and enqueue gracefully until
// the dispatch function is called.
event.post(1, 2);
event.post(3, 4);
event.post(5, 6);

queue.dispatch();
```

cc @pan- thoughts?
