### PR TITLE
Add dispatch_forever as a separate function with no timeout

### DIFF
--- a/EventQueue.h
+++ b/EventQueue.h
@@ -75,8 +75,8 @@ public:
      *                  value will dispatch events indefinitely
      *                  (default to -1)
      */
-    void dispatch(int ms);
-    void dispatch() { dispatch(-1); }
+    void dispatch(int ms=-1);
+    void dispatch_forever() { dispatch(); }
 
     /** Break out of a running event loop
      *


### PR DESCRIPTION
Unfortunately, with the recent addition of a type-infering `callback` function, the overloaded `dispatch` member function creates an ambiguity when passed to threads.

With `dispatch_forever` function, a thread for the event queue can be started simply like this:

``` cpp
t.start(&queue, &EventQueue::dispatch_forever);
```

Thanks to @bogdanm for the find/solution
