### PR TITLE
Remove use of gcc-specific struct initializers

### DIFF
--- a/Event.h
+++ b/Event.h
@@ -60,7 +60,7 @@ public:
                     return 0;
                 }
 
-                new (p) C((C){*reinterpret_cast<F*>(e+1)});
+                new (p) C(*reinterpret_cast<F*>(e+1));
                 equeue_event_delay(p, e->delay);
                 equeue_event_period(p, e->period);
                 equeue_event_dtor(p, &local::dtor);
@@ -226,27 +226,27 @@ public:
     // Convenience overloads for Event construction
     template <typename F, typename B0>
     Event(EventQueue *q, F f, B0 b0) {
-        new (this) Event(q, (EventQueue::context10<F, B0>){f, b0});
+        new (this) Event(q, EventQueue::context10<F, B0>(f, b0));
     }
 
     template <typename F, typename B0, typename B1>
     Event(EventQueue *q, F f, B0 b0, B1 b1) {
-        new (this) Event(q, (EventQueue::context20<F, B0, B1>){f, b0, b1});
+        new (this) Event(q, EventQueue::context20<F, B0, B1>(f, b0, b1));
     }
 
     template <typename F, typename B0, typename B1, typename B2>
     Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2) {
-        new (this) Event(q, (EventQueue::context30<F, B0, B1, B2>){f, b0, b1, b2});
+        new (this) Event(q, EventQueue::context30<F, B0, B1, B2>(f, b0, b1, b2));
     }
 
     template <typename F, typename B0, typename B1, typename B2, typename B3>
     Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3) {
-        new (this) Event(q, (EventQueue::context40<F, B0, B1, B2, B3>){f, b0, b1, b2, b3});
+        new (this) Event(q, EventQueue::context40<F, B0, B1, B2, B3>(f, b0, b1, b2, b3));
     }
 
     template <typename F, typename B0, typename B1, typename B2, typename B3, typename B4>
     Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
-        new (this) Event(q, (EventQueue::context50<F, B0, B1, B2, B3, B4>){f, b0, b1, b2, b3, b4});
+        new (this) Event(q, EventQueue::context50<F, B0, B1, B2, B3, B4>(f, b0, b1, b2, b3, b4));
     }
 
     template <typename T, typename R, typename B0>
@@ -382,7 +382,7 @@ public:
                     return 0;
                 }
 
-                new (p) C((C){*reinterpret_cast<F*>(e+1), a0});
+                new (p) C(*reinterpret_cast<F*>(e+1), a0);
                 equeue_event_delay(p, e->delay);
                 equeue_event_period(p, e->period);
                 equeue_event_dtor(p, &local::dtor);
@@ -548,27 +548,27 @@ public:
     // Convenience overloads for Event construction
     template <typename F, typename B0>
     Event(EventQueue *q, F f, B0 b0) {
-        new (this) Event(q, (EventQueue::context11<F, B0, A0>){f, b0});
+        new (this) Event(q, EventQueue::context11<F, B0, A0>(f, b0));
     }
 
     template <typename F, typename B0, typename B1>
     Event(EventQueue *q, F f, B0 b0, B1 b1) {
-        new (this) Event(q, (EventQueue::context21<F, B0, B1, A0>){f, b0, b1});
+        new (this) Event(q, EventQueue::context21<F, B0, B1, A0>(f, b0, b1));
     }
 
     template <typename F, typename B0, typename B1, typename B2>
     Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2) {
-        new (this) Event(q, (EventQueue::context31<F, B0, B1, B2, A0>){f, b0, b1, b2});
+        new (this) Event(q, EventQueue::context31<F, B0, B1, B2, A0>(f, b0, b1, b2));
     }
 
     template <typename F, typename B0, typename B1, typename B2, typename B3>
     Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3) {
-        new (this) Event(q, (EventQueue::context41<F, B0, B1, B2, B3, A0>){f, b0, b1, b2, b3});
+        new (this) Event(q, EventQueue::context41<F, B0, B1, B2, B3, A0>(f, b0, b1, b2, b3));
     }
 
     template <typename F, typename B0, typename B1, typename B2, typename B3, typename B4>
     Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
-        new (this) Event(q, (EventQueue::context51<F, B0, B1, B2, B3, B4, A0>){f, b0, b1, b2, b3, b4});
+        new (this) Event(q, EventQueue::context51<F, B0, B1, B2, B3, B4, A0>(f, b0, b1, b2, b3, b4));
     }
 
     template <typename T, typename R, typename B0>
@@ -704,7 +704,7 @@ public:
                     return 0;
                 }
 
-                new (p) C((C){*reinterpret_cast<F*>(e+1), a0, a1});
+                new (p) C(*reinterpret_cast<F*>(e+1), a0, a1);
                 equeue_event_delay(p, e->delay);
                 equeue_event_period(p, e->period);
                 equeue_event_dtor(p, &local::dtor);
@@ -870,27 +870,27 @@ public:
     // Convenience overloads for Event construction
     template <typename F, typename B0>
     Event(EventQueue *q, F f, B0 b0) {
-        new (this) Event(q, (EventQueue::context12<F, B0, A0, A1>){f, b0});
+        new (this) Event(q, EventQueue::context12<F, B0, A0, A1>(f, b0));
     }
 
     template <typename F, typename B0, typename B1>
     Event(EventQueue *q, F f, B0 b0, B1 b1) {
-        new (this) Event(q, (EventQueue::context22<F, B0, B1, A0, A1>){f, b0, b1});
+        new (this) Event(q, EventQueue::context22<F, B0, B1, A0, A1>(f, b0, b1));
     }
 
     template <typename F, typename B0, typename B1, typename B2>
     Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2) {
-        new (this) Event(q, (EventQueue::context32<F, B0, B1, B2, A0, A1>){f, b0, b1, b2});
+        new (this) Event(q, EventQueue::context32<F, B0, B1, B2, A0, A1>(f, b0, b1, b2));
     }
 
     template <typename F, typename B0, typename B1, typename B2, typename B3>
     Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3) {
-        new (this) Event(q, (EventQueue::context42<F, B0, B1, B2, B3, A0, A1>){f, b0, b1, b2, b3});
+        new (this) Event(q, EventQueue::context42<F, B0, B1, B2, B3, A0, A1>(f, b0, b1, b2, b3));
     }
 
     template <typename F, typename B0, typename B1, typename B2, typename B3, typename B4>
     Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
-        new (this) Event(q, (EventQueue::context52<F, B0, B1, B2, B3, B4, A0, A1>){f, b0, b1, b2, b3, b4});
+        new (this) Event(q, EventQueue::context52<F, B0, B1, B2, B3, B4, A0, A1>(f, b0, b1, b2, b3, b4));
     }
 
     template <typename T, typename R, typename B0>
@@ -1026,7 +1026,7 @@ public:
                     return 0;
                 }
 
-                new (p) C((C){*reinterpret_cast<F*>(e+1), a0, a1, a2});
+                new (p) C(*reinterpret_cast<F*>(e+1), a0, a1, a2);
                 equeue_event_delay(p, e->delay);
                 equeue_event_period(p, e->period);
                 equeue_event_dtor(p, &local::dtor);
@@ -1192,27 +1192,27 @@ public:
     // Convenience overloads for Event construction
     template <typename F, typename B0>
     Event(EventQueue *q, F f, B0 b0) {
-        new (this) Event(q, (EventQueue::context13<F, B0, A0, A1, A2>){f, b0});
+        new (this) Event(q, EventQueue::context13<F, B0, A0, A1, A2>(f, b0));
     }
 
     template <typename F, typename B0, typename B1>
     Event(EventQueue *q, F f, B0 b0, B1 b1) {
-        new (this) Event(q, (EventQueue::context23<F, B0, B1, A0, A1, A2>){f, b0, b1});
+        new (this) Event(q, EventQueue::context23<F, B0, B1, A0, A1, A2>(f, b0, b1));
     }
 
     template <typename F, typename B0, typename B1, typename B2>
     Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2) {
-        new (this) Event(q, (EventQueue::context33<F, B0, B1, B2, A0, A1, A2>){f, b0, b1, b2});
+        new (this) Event(q, EventQueue::context33<F, B0, B1, B2, A0, A1, A2>(f, b0, b1, b2));
     }
 
     template <typename F, typename B0, typename B1, typename B2, typename B3>
     Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3) {
-        new (this) Event(q, (EventQueue::context43<F, B0, B1, B2, B3, A0, A1, A2>){f, b0, b1, b2, b3});
+        new (this) Event(q, EventQueue::context43<F, B0, B1, B2, B3, A0, A1, A2>(f, b0, b1, b2, b3));
     }
 
     template <typename F, typename B0, typename B1, typename B2, typename B3, typename B4>
     Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
-        new (this) Event(q, (EventQueue::context53<F, B0, B1, B2, B3, B4, A0, A1, A2>){f, b0, b1, b2, b3, b4});
+        new (this) Event(q, EventQueue::context53<F, B0, B1, B2, B3, B4, A0, A1, A2>(f, b0, b1, b2, b3, b4));
     }
 
     template <typename T, typename R, typename B0>
@@ -1348,7 +1348,7 @@ public:
                     return 0;
                 }
 
-                new (p) C((C){*reinterpret_cast<F*>(e+1), a0, a1, a2, a3});
+                new (p) C(*reinterpret_cast<F*>(e+1), a0, a1, a2, a3);
                 equeue_event_delay(p, e->delay);
                 equeue_event_period(p, e->period);
                 equeue_event_dtor(p, &local::dtor);
@@ -1514,27 +1514,27 @@ public:
     // Convenience overloads for Event construction
     template <typename F, typename B0>
     Event(EventQueue *q, F f, B0 b0) {
-        new (this) Event(q, (EventQueue::context14<F, B0, A0, A1, A2, A3>){f, b0});
+        new (this) Event(q, EventQueue::context14<F, B0, A0, A1, A2, A3>(f, b0));
     }
 
     template <typename F, typename B0, typename B1>
     Event(EventQueue *q, F f, B0 b0, B1 b1) {
-        new (this) Event(q, (EventQueue::context24<F, B0, B1, A0, A1, A2, A3>){f, b0, b1});
+        new (this) Event(q, EventQueue::context24<F, B0, B1, A0, A1, A2, A3>(f, b0, b1));
     }
 
     template <typename F, typename B0, typename B1, typename B2>
     Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2) {
-        new (this) Event(q, (EventQueue::context34<F, B0, B1, B2, A0, A1, A2, A3>){f, b0, b1, b2});
+        new (this) Event(q, EventQueue::context34<F, B0, B1, B2, A0, A1, A2, A3>(f, b0, b1, b2));
     }
 
     template <typename F, typename B0, typename B1, typename B2, typename B3>
     Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3) {
-        new (this) Event(q, (EventQueue::context44<F, B0, B1, B2, B3, A0, A1, A2, A3>){f, b0, b1, b2, b3});
+        new (this) Event(q, EventQueue::context44<F, B0, B1, B2, B3, A0, A1, A2, A3>(f, b0, b1, b2, b3));
     }
 
     template <typename F, typename B0, typename B1, typename B2, typename B3, typename B4>
     Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
-        new (this) Event(q, (EventQueue::context54<F, B0, B1, B2, B3, B4, A0, A1, A2, A3>){f, b0, b1, b2, b3, b4});
+        new (this) Event(q, EventQueue::context54<F, B0, B1, B2, B3, B4, A0, A1, A2, A3>(f, b0, b1, b2, b3, b4));
     }
 
     template <typename T, typename R, typename B0>
@@ -1670,7 +1670,7 @@ public:
                     return 0;
                 }
 
-                new (p) C((C){*reinterpret_cast<F*>(e+1), a0, a1, a2, a3, a4});
+                new (p) C(*reinterpret_cast<F*>(e+1), a0, a1, a2, a3, a4);
                 equeue_event_delay(p, e->delay);
                 equeue_event_period(p, e->period);
                 equeue_event_dtor(p, &local::dtor);
@@ -1836,27 +1836,27 @@ public:
     // Convenience overloads for Event construction
     template <typename F, typename B0>
     Event(EventQueue *q, F f, B0 b0) {
-        new (this) Event(q, (EventQueue::context15<F, B0, A0, A1, A2, A3, A4>){f, b0});
+        new (this) Event(q, EventQueue::context15<F, B0, A0, A1, A2, A3, A4>(f, b0));
     }
 
     template <typename F, typename B0, typename B1>
     Event(EventQueue *q, F f, B0 b0, B1 b1) {
-        new (this) Event(q, (EventQueue::context25<F, B0, B1, A0, A1, A2, A3, A4>){f, b0, b1});
+        new (this) Event(q, EventQueue::context25<F, B0, B1, A0, A1, A2, A3, A4>(f, b0, b1));
     }
 
     template <typename F, typename B0, typename B1, typename B2>
     Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2) {
-        new (this) Event(q, (EventQueue::context35<F, B0, B1, B2, A0, A1, A2, A3, A4>){f, b0, b1, b2});
+        new (this) Event(q, EventQueue::context35<F, B0, B1, B2, A0, A1, A2, A3, A4>(f, b0, b1, b2));
     }
 
     template <typename F, typename B0, typename B1, typename B2, typename B3>
     Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3) {
-        new (this) Event(q, (EventQueue::context45<F, B0, B1, B2, B3, A0, A1, A2, A3, A4>){f, b0, b1, b2, b3});
+        new (this) Event(q, EventQueue::context45<F, B0, B1, B2, B3, A0, A1, A2, A3, A4>(f, b0, b1, b2, b3));
     }
 
     template <typename F, typename B0, typename B1, typename B2, typename B3, typename B4>
     Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
-        new (this) Event(q, (EventQueue::context55<F, B0, B1, B2, B3, B4, A0, A1, A2, A3, A4>){f, b0, b1, b2, b3, b4});
+        new (this) Event(q, EventQueue::context55<F, B0, B1, B2, B3, B4, A0, A1, A2, A3, A4>(f, b0, b1, b2, b3, b4));
     }
 
     template <typename T, typename R, typename B0>

--- a/EventQueue.h
+++ b/EventQueue.h
@@ -178,27 +178,27 @@ public:
 
     template <typename F, typename A0>
     int call(F f, A0 a0) {
-        return call((context10<F, A0>){f, a0});
+        return call(context10<F, A0>(f, a0));
     }
 
     template <typename F, typename A0, typename A1>
     int call(F f, A0 a0, A1 a1) {
-        return call((context20<F, A0, A1>){f, a0, a1});
+        return call(context20<F, A0, A1>(f, a0, a1));
     }
 
     template <typename F, typename A0, typename A1, typename A2>
     int call(F f, A0 a0, A1 a1, A2 a2) {
-        return call((context30<F, A0, A1, A2>){f, a0, a1, a2});
+        return call(context30<F, A0, A1, A2>(f, a0, a1, a2));
     }
 
     template <typename F, typename A0, typename A1, typename A2, typename A3>
     int call(F f, A0 a0, A1 a1, A2 a2, A3 a3) {
-        return call((context40<F, A0, A1, A2, A3>){f, a0, a1, a2, a3});
+        return call(context40<F, A0, A1, A2, A3>(f, a0, a1, a2, a3));
     }
 
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
     int call(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-        return call((context50<F, A0, A1, A2, A3, A4>){f, a0, a1, a2, a3, a4});
+        return call(context50<F, A0, A1, A2, A3, A4>(f, a0, a1, a2, a3, a4));
     }
     template <typename T, typename R>
     int call(T *obj, R (T::*method)()) {
@@ -355,27 +355,27 @@ public:
 
     template <typename F, typename A0>
     int call_in(int ms, F f, A0 a0) {
-        return call_in(ms, (context10<F, A0>){f, a0});
+        return call_in(ms, context10<F, A0>(f, a0));
     }
 
     template <typename F, typename A0, typename A1>
     int call_in(int ms, F f, A0 a0, A1 a1) {
-        return call_in(ms, (context20<F, A0, A1>){f, a0, a1});
+        return call_in(ms, context20<F, A0, A1>(f, a0, a1));
     }
 
     template <typename F, typename A0, typename A1, typename A2>
     int call_in(int ms, F f, A0 a0, A1 a1, A2 a2) {
-        return call_in(ms, (context30<F, A0, A1, A2>){f, a0, a1, a2});
+        return call_in(ms, context30<F, A0, A1, A2>(f, a0, a1, a2));
     }
 
     template <typename F, typename A0, typename A1, typename A2, typename A3>
     int call_in(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3) {
-        return call_in(ms, (context40<F, A0, A1, A2, A3>){f, a0, a1, a2, a3});
+        return call_in(ms, context40<F, A0, A1, A2, A3>(f, a0, a1, a2, a3));
     }
 
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
     int call_in(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-        return call_in(ms, (context50<F, A0, A1, A2, A3, A4>){f, a0, a1, a2, a3, a4});
+        return call_in(ms, context50<F, A0, A1, A2, A3, A4>(f, a0, a1, a2, a3, a4));
     }
     template <typename T, typename R>
     int call_in(int ms, T *obj, R (T::*method)()) {
@@ -533,27 +533,27 @@ public:
 
     template <typename F, typename A0>
     int call_every(int ms, F f, A0 a0) {
-        return call_every(ms, (context10<F, A0>){f, a0});
+        return call_every(ms, context10<F, A0>(f, a0));
     }
 
     template <typename F, typename A0, typename A1>
     int call_every(int ms, F f, A0 a0, A1 a1) {
-        return call_every(ms, (context20<F, A0, A1>){f, a0, a1});
+        return call_every(ms, context20<F, A0, A1>(f, a0, a1));
     }
 
     template <typename F, typename A0, typename A1, typename A2>
     int call_every(int ms, F f, A0 a0, A1 a1, A2 a2) {
-        return call_every(ms, (context30<F, A0, A1, A2>){f, a0, a1, a2});
+        return call_every(ms, context30<F, A0, A1, A2>(f, a0, a1, a2));
     }
 
     template <typename F, typename A0, typename A1, typename A2, typename A3>
     int call_every(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3) {
-        return call_every(ms, (context40<F, A0, A1, A2, A3>){f, a0, a1, a2, a3});
+        return call_every(ms, context40<F, A0, A1, A2, A3>(f, a0, a1, a2, a3));
     }
 
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
     int call_every(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-        return call_every(ms, (context50<F, A0, A1, A2, A3, A4>){f, a0, a1, a2, a3, a4});
+        return call_every(ms, context50<F, A0, A1, A2, A3, A4>(f, a0, a1, a2, a3, a4));
     }
     template <typename T, typename R>
     int call_every(int ms, T *obj, R (T::*method)()) {
@@ -783,6 +783,10 @@ protected:
     template <typename F>
     struct context00 {
         F f;
+
+        context00(F f)
+            : f(f) {}
+
         void operator()() {
             f();
         }
@@ -791,6 +795,10 @@ protected:
     template <typename F, typename A0>
     struct context10 {
         F f; A0 a0;
+
+        context10(F f, A0 a0)
+            : f(f), a0(a0) {}
+
         void operator()() {
             f(a0);
         }
@@ -799,6 +807,10 @@ protected:
     template <typename F, typename A0, typename A1>
     struct context20 {
         F f; A0 a0; A1 a1;
+
+        context20(F f, A0 a0, A1 a1)
+            : f(f), a0(a0), a1(a1) {}
+
         void operator()() {
             f(a0, a1);
         }
@@ -807,6 +819,10 @@ protected:
     template <typename F, typename A0, typename A1, typename A2>
     struct context30 {
         F f; A0 a0; A1 a1; A2 a2;
+
+        context30(F f, A0 a0, A1 a1, A2 a2)
+            : f(f), a0(a0), a1(a1), a2(a2) {}
+
         void operator()() {
             f(a0, a1, a2);
         }
@@ -815,6 +831,10 @@ protected:
     template <typename F, typename A0, typename A1, typename A2, typename A3>
     struct context40 {
         F f; A0 a0; A1 a1; A2 a2; A3 a3;
+
+        context40(F f, A0 a0, A1 a1, A2 a2, A3 a3)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3) {}
+
         void operator()() {
             f(a0, a1, a2, a3);
         }
@@ -823,6 +843,10 @@ protected:
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
     struct context50 {
         F f; A0 a0; A1 a1; A2 a2; A3 a3; A4 a4;
+
+        context50(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3), a4(a4) {}
+
         void operator()() {
             f(a0, a1, a2, a3, a4);
         }
@@ -831,6 +855,10 @@ protected:
     template <typename F, typename B0>
     struct context01 {
         F f;
+
+        context01(F f)
+            : f(f) {}
+
         void operator()(B0 b0) {
             f(b0);
         }
@@ -839,6 +867,10 @@ protected:
     template <typename F, typename A0, typename B0>
     struct context11 {
         F f; A0 a0;
+
+        context11(F f, A0 a0)
+            : f(f), a0(a0) {}
+
         void operator()(B0 b0) {
             f(a0, b0);
         }
@@ -847,6 +879,10 @@ protected:
     template <typename F, typename A0, typename A1, typename B0>
     struct context21 {
         F f; A0 a0; A1 a1;
+
+        context21(F f, A0 a0, A1 a1)
+            : f(f), a0(a0), a1(a1) {}
+
         void operator()(B0 b0) {
             f(a0, a1, b0);
         }
@@ -855,6 +891,10 @@ protected:
     template <typename F, typename A0, typename A1, typename A2, typename B0>
     struct context31 {
         F f; A0 a0; A1 a1; A2 a2;
+
+        context31(F f, A0 a0, A1 a1, A2 a2)
+            : f(f), a0(a0), a1(a1), a2(a2) {}
+
         void operator()(B0 b0) {
             f(a0, a1, a2, b0);
         }
@@ -863,6 +903,10 @@ protected:
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename B0>
     struct context41 {
         F f; A0 a0; A1 a1; A2 a2; A3 a3;
+
+        context41(F f, A0 a0, A1 a1, A2 a2, A3 a3)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3) {}
+
         void operator()(B0 b0) {
             f(a0, a1, a2, a3, b0);
         }
@@ -871,6 +915,10 @@ protected:
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4, typename B0>
     struct context51 {
         F f; A0 a0; A1 a1; A2 a2; A3 a3; A4 a4;
+
+        context51(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3), a4(a4) {}
+
         void operator()(B0 b0) {
             f(a0, a1, a2, a3, a4, b0);
         }
@@ -879,6 +927,10 @@ protected:
     template <typename F, typename B0, typename B1>
     struct context02 {
         F f;
+
+        context02(F f)
+            : f(f) {}
+
         void operator()(B0 b0, B1 b1) {
             f(b0, b1);
         }
@@ -887,6 +939,10 @@ protected:
     template <typename F, typename A0, typename B0, typename B1>
     struct context12 {
         F f; A0 a0;
+
+        context12(F f, A0 a0)
+            : f(f), a0(a0) {}
+
         void operator()(B0 b0, B1 b1) {
             f(a0, b0, b1);
         }
@@ -895,6 +951,10 @@ protected:
     template <typename F, typename A0, typename A1, typename B0, typename B1>
     struct context22 {
         F f; A0 a0; A1 a1;
+
+        context22(F f, A0 a0, A1 a1)
+            : f(f), a0(a0), a1(a1) {}
+
         void operator()(B0 b0, B1 b1) {
             f(a0, a1, b0, b1);
         }
@@ -903,6 +963,10 @@ protected:
     template <typename F, typename A0, typename A1, typename A2, typename B0, typename B1>
     struct context32 {
         F f; A0 a0; A1 a1; A2 a2;
+
+        context32(F f, A0 a0, A1 a1, A2 a2)
+            : f(f), a0(a0), a1(a1), a2(a2) {}
+
         void operator()(B0 b0, B1 b1) {
             f(a0, a1, a2, b0, b1);
         }
@@ -911,6 +975,10 @@ protected:
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename B0, typename B1>
     struct context42 {
         F f; A0 a0; A1 a1; A2 a2; A3 a3;
+
+        context42(F f, A0 a0, A1 a1, A2 a2, A3 a3)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3) {}
+
         void operator()(B0 b0, B1 b1) {
             f(a0, a1, a2, a3, b0, b1);
         }
@@ -919,6 +987,10 @@ protected:
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4, typename B0, typename B1>
     struct context52 {
         F f; A0 a0; A1 a1; A2 a2; A3 a3; A4 a4;
+
+        context52(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3), a4(a4) {}
+
         void operator()(B0 b0, B1 b1) {
             f(a0, a1, a2, a3, a4, b0, b1);
         }
@@ -927,6 +999,10 @@ protected:
     template <typename F, typename B0, typename B1, typename B2>
     struct context03 {
         F f;
+
+        context03(F f)
+            : f(f) {}
+
         void operator()(B0 b0, B1 b1, B2 b2) {
             f(b0, b1, b2);
         }
@@ -935,6 +1011,10 @@ protected:
     template <typename F, typename A0, typename B0, typename B1, typename B2>
     struct context13 {
         F f; A0 a0;
+
+        context13(F f, A0 a0)
+            : f(f), a0(a0) {}
+
         void operator()(B0 b0, B1 b1, B2 b2) {
             f(a0, b0, b1, b2);
         }
@@ -943,6 +1023,10 @@ protected:
     template <typename F, typename A0, typename A1, typename B0, typename B1, typename B2>
     struct context23 {
         F f; A0 a0; A1 a1;
+
+        context23(F f, A0 a0, A1 a1)
+            : f(f), a0(a0), a1(a1) {}
+
         void operator()(B0 b0, B1 b1, B2 b2) {
             f(a0, a1, b0, b1, b2);
         }
@@ -951,6 +1035,10 @@ protected:
     template <typename F, typename A0, typename A1, typename A2, typename B0, typename B1, typename B2>
     struct context33 {
         F f; A0 a0; A1 a1; A2 a2;
+
+        context33(F f, A0 a0, A1 a1, A2 a2)
+            : f(f), a0(a0), a1(a1), a2(a2) {}
+
         void operator()(B0 b0, B1 b1, B2 b2) {
             f(a0, a1, a2, b0, b1, b2);
         }
@@ -959,6 +1047,10 @@ protected:
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename B0, typename B1, typename B2>
     struct context43 {
         F f; A0 a0; A1 a1; A2 a2; A3 a3;
+
+        context43(F f, A0 a0, A1 a1, A2 a2, A3 a3)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3) {}
+
         void operator()(B0 b0, B1 b1, B2 b2) {
             f(a0, a1, a2, a3, b0, b1, b2);
         }
@@ -967,6 +1059,10 @@ protected:
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4, typename B0, typename B1, typename B2>
     struct context53 {
         F f; A0 a0; A1 a1; A2 a2; A3 a3; A4 a4;
+
+        context53(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3), a4(a4) {}
+
         void operator()(B0 b0, B1 b1, B2 b2) {
             f(a0, a1, a2, a3, a4, b0, b1, b2);
         }
@@ -975,6 +1071,10 @@ protected:
     template <typename F, typename B0, typename B1, typename B2, typename B3>
     struct context04 {
         F f;
+
+        context04(F f)
+            : f(f) {}
+
         void operator()(B0 b0, B1 b1, B2 b2, B3 b3) {
             f(b0, b1, b2, b3);
         }
@@ -983,6 +1083,10 @@ protected:
     template <typename F, typename A0, typename B0, typename B1, typename B2, typename B3>
     struct context14 {
         F f; A0 a0;
+
+        context14(F f, A0 a0)
+            : f(f), a0(a0) {}
+
         void operator()(B0 b0, B1 b1, B2 b2, B3 b3) {
             f(a0, b0, b1, b2, b3);
         }
@@ -991,6 +1095,10 @@ protected:
     template <typename F, typename A0, typename A1, typename B0, typename B1, typename B2, typename B3>
     struct context24 {
         F f; A0 a0; A1 a1;
+
+        context24(F f, A0 a0, A1 a1)
+            : f(f), a0(a0), a1(a1) {}
+
         void operator()(B0 b0, B1 b1, B2 b2, B3 b3) {
             f(a0, a1, b0, b1, b2, b3);
         }
@@ -999,6 +1107,10 @@ protected:
     template <typename F, typename A0, typename A1, typename A2, typename B0, typename B1, typename B2, typename B3>
     struct context34 {
         F f; A0 a0; A1 a1; A2 a2;
+
+        context34(F f, A0 a0, A1 a1, A2 a2)
+            : f(f), a0(a0), a1(a1), a2(a2) {}
+
         void operator()(B0 b0, B1 b1, B2 b2, B3 b3) {
             f(a0, a1, a2, b0, b1, b2, b3);
         }
@@ -1007,6 +1119,10 @@ protected:
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename B0, typename B1, typename B2, typename B3>
     struct context44 {
         F f; A0 a0; A1 a1; A2 a2; A3 a3;
+
+        context44(F f, A0 a0, A1 a1, A2 a2, A3 a3)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3) {}
+
         void operator()(B0 b0, B1 b1, B2 b2, B3 b3) {
             f(a0, a1, a2, a3, b0, b1, b2, b3);
         }
@@ -1015,6 +1131,10 @@ protected:
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4, typename B0, typename B1, typename B2, typename B3>
     struct context54 {
         F f; A0 a0; A1 a1; A2 a2; A3 a3; A4 a4;
+
+        context54(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3), a4(a4) {}
+
         void operator()(B0 b0, B1 b1, B2 b2, B3 b3) {
             f(a0, a1, a2, a3, a4, b0, b1, b2, b3);
         }
@@ -1023,6 +1143,10 @@ protected:
     template <typename F, typename B0, typename B1, typename B2, typename B3, typename B4>
     struct context05 {
         F f;
+
+        context05(F f)
+            : f(f) {}
+
         void operator()(B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
             f(b0, b1, b2, b3, b4);
         }
@@ -1031,6 +1155,10 @@ protected:
     template <typename F, typename A0, typename B0, typename B1, typename B2, typename B3, typename B4>
     struct context15 {
         F f; A0 a0;
+
+        context15(F f, A0 a0)
+            : f(f), a0(a0) {}
+
         void operator()(B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
             f(a0, b0, b1, b2, b3, b4);
         }
@@ -1039,6 +1167,10 @@ protected:
     template <typename F, typename A0, typename A1, typename B0, typename B1, typename B2, typename B3, typename B4>
     struct context25 {
         F f; A0 a0; A1 a1;
+
+        context25(F f, A0 a0, A1 a1)
+            : f(f), a0(a0), a1(a1) {}
+
         void operator()(B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
             f(a0, a1, b0, b1, b2, b3, b4);
         }
@@ -1047,6 +1179,10 @@ protected:
     template <typename F, typename A0, typename A1, typename A2, typename B0, typename B1, typename B2, typename B3, typename B4>
     struct context35 {
         F f; A0 a0; A1 a1; A2 a2;
+
+        context35(F f, A0 a0, A1 a1, A2 a2)
+            : f(f), a0(a0), a1(a1), a2(a2) {}
+
         void operator()(B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
             f(a0, a1, a2, b0, b1, b2, b3, b4);
         }
@@ -1055,6 +1191,10 @@ protected:
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename B0, typename B1, typename B2, typename B3, typename B4>
     struct context45 {
         F f; A0 a0; A1 a1; A2 a2; A3 a3;
+
+        context45(F f, A0 a0, A1 a1, A2 a2, A3 a3)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3) {}
+
         void operator()(B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
             f(a0, a1, a2, a3, b0, b1, b2, b3, b4);
         }
@@ -1063,6 +1203,10 @@ protected:
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4, typename B0, typename B1, typename B2, typename B3, typename B4>
     struct context55 {
         F f; A0 a0; A1 a1; A2 a2; A3 a3; A4 a4;
+
+        context55(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
+            : f(f), a0(a0), a1(a1), a2(a2), a3(a3), a4(a4) {}
+
         void operator()(B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
             f(a0, a1, a2, a3, a4, b0, b1, b2, b3, b4);
         }


### PR DESCRIPTION
Although it saves a significant number of lines, the previously used struct initializers are limited to gcc-extensions, C99, and C++11, causing compilation errors on C++03 compilers such as ARMCC and IAR.

Effectively reverts 1db78bc in #18 
