### PR TITLE
Increase type-infering functions to all possible event permutations

### DIFF
--- a/Event.h
+++ b/Event.h
@@ -2726,6 +2726,1596 @@ Event<void()> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2
     return Event<void()>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
 }
 
+template <typename R, typename A0>
+Event<void(A0)> EventQueue::event(R (*func)(A0)) {
+    return Event<void(A0)>(this, func);
+}
+
+template <typename F, typename R, typename A0>
+Event<void(A0)> EventQueue::event(F func, typename detail::enable_if<
+            detail::is_type<R (F::*)(A0), &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func);
+}
+
+template <typename F, typename R, typename A0>
+Event<void(A0)> EventQueue::event(const F func, typename detail::enable_if<
+            detail::is_type<R (F::*)(A0) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func);
+}
+
+template <typename F, typename R, typename A0>
+Event<void(A0)> EventQueue::event(volatile F func, typename detail::enable_if<
+            detail::is_type<R (F::*)(A0) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func);
+}
+
+template <typename F, typename R, typename A0>
+Event<void(A0)> EventQueue::event(const volatile F func, typename detail::enable_if<
+            detail::is_type<R (F::*)(A0) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func);
+}
+
+template <typename T, typename R, typename A0>
+Event<void(A0)> EventQueue::event(T *obj, R (T::*method)(A0)) {
+    return Event<void(A0)>(this, mbed::callback(obj, method));
+}
+
+template <typename T, typename R, typename A0>
+Event<void(A0)> EventQueue::event(const T *obj, R (T::*method)(A0) const) {
+    return Event<void(A0)>(this, mbed::callback(obj, method));
+}
+
+template <typename T, typename R, typename A0>
+Event<void(A0)> EventQueue::event(volatile T *obj, R (T::*method)(A0) volatile) {
+    return Event<void(A0)>(this, mbed::callback(obj, method));
+}
+
+template <typename T, typename R, typename A0>
+Event<void(A0)> EventQueue::event(const volatile T *obj, R (T::*method)(A0) const volatile) {
+    return Event<void(A0)>(this, mbed::callback(obj, method));
+}
+
+template <typename R, typename B0, typename C0, typename A0>
+Event<void(A0)> EventQueue::event(R (*func)(B0, A0), C0 c0) {
+    return Event<void(A0)>(this, func, c0);
+}
+
+template <typename F, typename R, typename B0, typename C0, typename A0>
+Event<void(A0)> EventQueue::event(F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, A0), &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func, c0);
+}
+
+template <typename F, typename R, typename B0, typename C0, typename A0>
+Event<void(A0)> EventQueue::event(const F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, A0) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func, c0);
+}
+
+template <typename F, typename R, typename B0, typename C0, typename A0>
+Event<void(A0)> EventQueue::event(volatile F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, A0) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func, c0);
+}
+
+template <typename F, typename R, typename B0, typename C0, typename A0>
+Event<void(A0)> EventQueue::event(const volatile F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, A0) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func, c0);
+}
+
+template <typename T, typename R, typename B0, typename C0, typename A0>
+Event<void(A0)> EventQueue::event(T *obj, R (T::*method)(B0, A0), C0 c0) {
+    return Event<void(A0)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename T, typename R, typename B0, typename C0, typename A0>
+Event<void(A0)> EventQueue::event(const T *obj, R (T::*method)(B0, A0) const, C0 c0) {
+    return Event<void(A0)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename T, typename R, typename B0, typename C0, typename A0>
+Event<void(A0)> EventQueue::event(volatile T *obj, R (T::*method)(B0, A0) volatile, C0 c0) {
+    return Event<void(A0)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename T, typename R, typename B0, typename C0, typename A0>
+Event<void(A0)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, A0) const volatile, C0 c0) {
+    return Event<void(A0)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
+Event<void(A0)> EventQueue::event(R (*func)(B0, B1, A0), C0 c0, C1 c1) {
+    return Event<void(A0)>(this, func, c0, c1);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
+Event<void(A0)> EventQueue::event(F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, A0), &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func, c0, c1);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
+Event<void(A0)> EventQueue::event(const F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, A0) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func, c0, c1);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
+Event<void(A0)> EventQueue::event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, A0) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func, c0, c1);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
+Event<void(A0)> EventQueue::event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, A0) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func, c0, c1);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
+Event<void(A0)> EventQueue::event(T *obj, R (T::*method)(B0, B1, A0), C0 c0, C1 c1) {
+    return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
+Event<void(A0)> EventQueue::event(const T *obj, R (T::*method)(B0, B1, A0) const, C0 c0, C1 c1) {
+    return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
+Event<void(A0)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, A0) volatile, C0 c0, C1 c1) {
+    return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
+Event<void(A0)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, A0) const volatile, C0 c0, C1 c1) {
+    return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
+Event<void(A0)> EventQueue::event(R (*func)(B0, B1, B2, A0), C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0)>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
+Event<void(A0)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, A0), &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
+Event<void(A0)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, A0) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
+Event<void(A0)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, A0) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
+Event<void(A0)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, A0) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func, c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
+Event<void(A0)> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, A0), C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
+Event<void(A0)> EventQueue::event(const T *obj, R (T::*method)(B0, B1, B2, A0) const, C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
+Event<void(A0)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2, A0) volatile, C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
+Event<void(A0)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0) const volatile, C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
+Event<void(A0)> EventQueue::event(R (*func)(B0, B1, B2, B3, A0), C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
+Event<void(A0)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, A0), &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
+Event<void(A0)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, A0) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
+Event<void(A0)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, A0) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
+Event<void(A0)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, A0) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
+Event<void(A0)> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, B3, A0), C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
+Event<void(A0)> EventQueue::event(const T *obj, R (T::*method)(B0, B1, B2, B3, A0) const, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
+Event<void(A0)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0) volatile, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
+Event<void(A0)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0) const volatile, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
+Event<void(A0)> EventQueue::event(R (*func)(B0, B1, B2, B3, B4, A0), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
+Event<void(A0)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0), &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
+Event<void(A0)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
+Event<void(A0)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
+Event<void(A0)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
+Event<void(A0)> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
+Event<void(A0)> EventQueue::event(const T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0) const, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
+Event<void(A0)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0) volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
+Event<void(A0)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename R, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(R (*func)(A0, A1)) {
+    return Event<void(A0, A1)>(this, func);
+}
+
+template <typename F, typename R, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(F func, typename detail::enable_if<
+            detail::is_type<R (F::*)(A0, A1), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func);
+}
+
+template <typename F, typename R, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const F func, typename detail::enable_if<
+            detail::is_type<R (F::*)(A0, A1) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func);
+}
+
+template <typename F, typename R, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(volatile F func, typename detail::enable_if<
+            detail::is_type<R (F::*)(A0, A1) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func);
+}
+
+template <typename F, typename R, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const volatile F func, typename detail::enable_if<
+            detail::is_type<R (F::*)(A0, A1) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func);
+}
+
+template <typename T, typename R, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(T *obj, R (T::*method)(A0, A1)) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method));
+}
+
+template <typename T, typename R, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const T *obj, R (T::*method)(A0, A1) const) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method));
+}
+
+template <typename T, typename R, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(volatile T *obj, R (T::*method)(A0, A1) volatile) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method));
+}
+
+template <typename T, typename R, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const volatile T *obj, R (T::*method)(A0, A1) const volatile) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method));
+}
+
+template <typename R, typename B0, typename C0, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(R (*func)(B0, A0, A1), C0 c0) {
+    return Event<void(A0, A1)>(this, func, c0);
+}
+
+template <typename F, typename R, typename B0, typename C0, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, A0, A1), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func, c0);
+}
+
+template <typename F, typename R, typename B0, typename C0, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, A0, A1) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func, c0);
+}
+
+template <typename F, typename R, typename B0, typename C0, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(volatile F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, A0, A1) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func, c0);
+}
+
+template <typename F, typename R, typename B0, typename C0, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const volatile F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, A0, A1) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func, c0);
+}
+
+template <typename T, typename R, typename B0, typename C0, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(T *obj, R (T::*method)(B0, A0, A1), C0 c0) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename T, typename R, typename B0, typename C0, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const T *obj, R (T::*method)(B0, A0, A1) const, C0 c0) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename T, typename R, typename B0, typename C0, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(volatile T *obj, R (T::*method)(B0, A0, A1) volatile, C0 c0) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename T, typename R, typename B0, typename C0, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, A0, A1) const volatile, C0 c0) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(R (*func)(B0, B1, A0, A1), C0 c0, C1 c1) {
+    return Event<void(A0, A1)>(this, func, c0, c1);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, A0, A1), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func, c0, c1);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, A0, A1) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func, c0, c1);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, A0, A1) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func, c0, c1);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, A0, A1) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func, c0, c1);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(T *obj, R (T::*method)(B0, B1, A0, A1), C0 c0, C1 c1) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const T *obj, R (T::*method)(B0, B1, A0, A1) const, C0 c0, C1 c1) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, A0, A1) volatile, C0 c0, C1 c1) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, A0, A1) const volatile, C0 c0, C1 c1) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(R (*func)(B0, B1, B2, A0, A1), C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1)>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, A0, A1), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, A0, A1) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, A0, A1) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, A0, A1) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func, c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, A0, A1), C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const T *obj, R (T::*method)(B0, B1, B2, A0, A1) const, C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1) volatile, C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1) const volatile, C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(R (*func)(B0, B1, B2, B3, A0, A1), C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1), C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1) const, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1) volatile, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1) const volatile, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(R (*func)(B0, B1, B2, B3, B4, A0, A1), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1) const, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1) volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
+Event<void(A0, A1)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename R, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(R (*func)(A0, A1, A2)) {
+    return Event<void(A0, A1, A2)>(this, func);
+}
+
+template <typename F, typename R, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(F func, typename detail::enable_if<
+            detail::is_type<R (F::*)(A0, A1, A2), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func);
+}
+
+template <typename F, typename R, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const F func, typename detail::enable_if<
+            detail::is_type<R (F::*)(A0, A1, A2) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func);
+}
+
+template <typename F, typename R, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(volatile F func, typename detail::enable_if<
+            detail::is_type<R (F::*)(A0, A1, A2) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func);
+}
+
+template <typename F, typename R, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const volatile F func, typename detail::enable_if<
+            detail::is_type<R (F::*)(A0, A1, A2) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func);
+}
+
+template <typename T, typename R, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(T *obj, R (T::*method)(A0, A1, A2)) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method));
+}
+
+template <typename T, typename R, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const T *obj, R (T::*method)(A0, A1, A2) const) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method));
+}
+
+template <typename T, typename R, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(volatile T *obj, R (T::*method)(A0, A1, A2) volatile) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method));
+}
+
+template <typename T, typename R, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const volatile T *obj, R (T::*method)(A0, A1, A2) const volatile) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method));
+}
+
+template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(R (*func)(B0, A0, A1, A2), C0 c0) {
+    return Event<void(A0, A1, A2)>(this, func, c0);
+}
+
+template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, A0, A1, A2), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func, c0);
+}
+
+template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, A0, A1, A2) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func, c0);
+}
+
+template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(volatile F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, A0, A1, A2) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func, c0);
+}
+
+template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const volatile F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, A0, A1, A2) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func, c0);
+}
+
+template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(T *obj, R (T::*method)(B0, A0, A1, A2), C0 c0) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const T *obj, R (T::*method)(B0, A0, A1, A2) const, C0 c0) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(volatile T *obj, R (T::*method)(B0, A0, A1, A2) volatile, C0 c0) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, A0, A1, A2) const volatile, C0 c0) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(R (*func)(B0, B1, A0, A1, A2), C0 c0, C1 c1) {
+    return Event<void(A0, A1, A2)>(this, func, c0, c1);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, A0, A1, A2), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func, c0, c1);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, A0, A1, A2) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func, c0, c1);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, A0, A1, A2) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func, c0, c1);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, A0, A1, A2) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func, c0, c1);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(T *obj, R (T::*method)(B0, B1, A0, A1, A2), C0 c0, C1 c1) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const T *obj, R (T::*method)(B0, B1, A0, A1, A2) const, C0 c0, C1 c1) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, A0, A1, A2) volatile, C0 c0, C1 c1) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, A0, A1, A2) const volatile, C0 c0, C1 c1) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(R (*func)(B0, B1, B2, A0, A1, A2), C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2), C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2) const, C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2) volatile, C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2) const volatile, C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(R (*func)(B0, B1, B2, B3, A0, A1, A2), C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2), C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2) const, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2) volatile, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2) const volatile, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(R (*func)(B0, B1, B2, B3, B4, A0, A1, A2), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2) const, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2) volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
+Event<void(A0, A1, A2)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename R, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(R (*func)(A0, A1, A2, A3)) {
+    return Event<void(A0, A1, A2, A3)>(this, func);
+}
+
+template <typename F, typename R, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(F func, typename detail::enable_if<
+            detail::is_type<R (F::*)(A0, A1, A2, A3), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func);
+}
+
+template <typename F, typename R, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const F func, typename detail::enable_if<
+            detail::is_type<R (F::*)(A0, A1, A2, A3) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func);
+}
+
+template <typename F, typename R, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(volatile F func, typename detail::enable_if<
+            detail::is_type<R (F::*)(A0, A1, A2, A3) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func);
+}
+
+template <typename F, typename R, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile F func, typename detail::enable_if<
+            detail::is_type<R (F::*)(A0, A1, A2, A3) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func);
+}
+
+template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(T *obj, R (T::*method)(A0, A1, A2, A3)) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method));
+}
+
+template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const T *obj, R (T::*method)(A0, A1, A2, A3) const) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method));
+}
+
+template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(volatile T *obj, R (T::*method)(A0, A1, A2, A3) volatile) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method));
+}
+
+template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile T *obj, R (T::*method)(A0, A1, A2, A3) const volatile) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method));
+}
+
+template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(R (*func)(B0, A0, A1, A2, A3), C0 c0) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0);
+}
+
+template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, A0, A1, A2, A3), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0);
+}
+
+template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, A0, A1, A2, A3) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0);
+}
+
+template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(volatile F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, A0, A1, A2, A3) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0);
+}
+
+template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, A0, A1, A2, A3) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0);
+}
+
+template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(T *obj, R (T::*method)(B0, A0, A1, A2, A3), C0 c0) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const T *obj, R (T::*method)(B0, A0, A1, A2, A3) const, C0 c0) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(volatile T *obj, R (T::*method)(B0, A0, A1, A2, A3) volatile, C0 c0) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, A0, A1, A2, A3) const volatile, C0 c0) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(R (*func)(B0, B1, A0, A1, A2, A3), C0 c0, C1 c1) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3), C0 c0, C1 c1) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3) const, C0 c0, C1 c1) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3) volatile, C0 c0, C1 c1) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3) const volatile, C0 c0, C1 c1) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(R (*func)(B0, B1, B2, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3) const, C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3) volatile, C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3) const volatile, C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(R (*func)(B0, B1, B2, B3, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3) const, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3) volatile, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3) const volatile, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(R (*func)(B0, B1, B2, B3, B4, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3) const, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3) volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
+Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(R (*func)(A0, A1, A2, A3, A4)) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func);
+}
+
+template <typename F, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(F func, typename detail::enable_if<
+            detail::is_type<R (F::*)(A0, A1, A2, A3, A4), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func);
+}
+
+template <typename F, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const F func, typename detail::enable_if<
+            detail::is_type<R (F::*)(A0, A1, A2, A3, A4) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func);
+}
+
+template <typename F, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(volatile F func, typename detail::enable_if<
+            detail::is_type<R (F::*)(A0, A1, A2, A3, A4) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func);
+}
+
+template <typename F, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile F func, typename detail::enable_if<
+            detail::is_type<R (F::*)(A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func);
+}
+
+template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(T *obj, R (T::*method)(A0, A1, A2, A3, A4)) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method));
+}
+
+template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const T *obj, R (T::*method)(A0, A1, A2, A3, A4) const) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method));
+}
+
+template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(volatile T *obj, R (T::*method)(A0, A1, A2, A3, A4) volatile) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method));
+}
+
+template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile T *obj, R (T::*method)(A0, A1, A2, A3, A4) const volatile) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method));
+}
+
+template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(R (*func)(B0, A0, A1, A2, A3, A4), C0 c0) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0);
+}
+
+template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, A0, A1, A2, A3, A4), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0);
+}
+
+template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, A0, A1, A2, A3, A4) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0);
+}
+
+template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(volatile F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, A0, A1, A2, A3, A4) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0);
+}
+
+template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0);
+}
+
+template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(T *obj, R (T::*method)(B0, A0, A1, A2, A3, A4), C0 c0) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const T *obj, R (T::*method)(B0, A0, A1, A2, A3, A4) const, C0 c0) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(volatile T *obj, R (T::*method)(B0, A0, A1, A2, A3, A4) volatile, C0 c0) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, A0, A1, A2, A3, A4) const volatile, C0 c0) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0);
+}
+
+template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(R (*func)(B0, B1, A0, A1, A2, A3, A4), C0 c0, C1 c1) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3, A4), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3, A4) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3, A4) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3, A4), C0 c0, C1 c1) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3, A4) const, C0 c0, C1 c1) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3, A4) volatile, C0 c0, C1 c1) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3, A4) const volatile, C0 c0, C1 c1) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(R (*func)(B0, B1, B2, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3, A4), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3, A4) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3, A4) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3, A4) const, C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3, A4) volatile, C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3, A4) const volatile, C0 c0, C1 c1, C2 c2) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(R (*func)(B0, B1, B2, B3, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3, A4), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3, A4) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3, A4) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3, A4) const, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3, A4) volatile, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3, A4) const volatile, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(R (*func)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4), &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) const, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) const, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
+Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
 }
 
 #endif

--- a/Event.h
+++ b/Event.h
@@ -226,41 +226,41 @@ public:
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0>
-    Event(EventQueue *q, F f, B0 b0) {
-        new (this) Event(q, EventQueue::context10<F, B0>(f, b0));
+    template <typename F, typename C0>
+    Event(EventQueue *q, F f, C0 c0) {
+        new (this) Event(q, EventQueue::context10<F, C0>(f, c0));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1>
-    Event(EventQueue *q, F f, B0 b0, B1 b1) {
-        new (this) Event(q, EventQueue::context20<F, B0, B1>(f, b0, b1));
+    template <typename F, typename C0, typename C1>
+    Event(EventQueue *q, F f, C0 c0, C1 c1) {
+        new (this) Event(q, EventQueue::context20<F, C0, C1>(f, c0, c1));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1, typename B2>
-    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2) {
-        new (this) Event(q, EventQueue::context30<F, B0, B1, B2>(f, b0, b1, b2));
+    template <typename F, typename C0, typename C1, typename C2>
+    Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2) {
+        new (this) Event(q, EventQueue::context30<F, C0, C1, C2>(f, c0, c1, c2));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1, typename B2, typename B3>
-    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3) {
-        new (this) Event(q, EventQueue::context40<F, B0, B1, B2, B3>(f, b0, b1, b2, b3));
+    template <typename F, typename C0, typename C1, typename C2, typename C3>
+    Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3) {
+        new (this) Event(q, EventQueue::context40<F, C0, C1, C2, C3>(f, c0, c1, c2, c3));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1, typename B2, typename B3, typename B4>
-    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
-        new (this) Event(q, EventQueue::context50<F, B0, B1, B2, B3, B4>(f, b0, b1, b2, b3, b4));
+    template <typename F, typename C0, typename C1, typename C2, typename C3, typename C4>
+    Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+        new (this) Event(q, EventQueue::context50<F, C0, C1, C2, C3, C4>(f, c0, c1, c2, c3, c4));
     }
 
     /** Create an event
@@ -622,41 +622,41 @@ public:
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0>
-    Event(EventQueue *q, F f, B0 b0) {
-        new (this) Event(q, EventQueue::context11<F, B0, A0>(f, b0));
+    template <typename F, typename C0>
+    Event(EventQueue *q, F f, C0 c0) {
+        new (this) Event(q, EventQueue::context11<F, C0, A0>(f, c0));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1>
-    Event(EventQueue *q, F f, B0 b0, B1 b1) {
-        new (this) Event(q, EventQueue::context21<F, B0, B1, A0>(f, b0, b1));
+    template <typename F, typename C0, typename C1>
+    Event(EventQueue *q, F f, C0 c0, C1 c1) {
+        new (this) Event(q, EventQueue::context21<F, C0, C1, A0>(f, c0, c1));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1, typename B2>
-    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2) {
-        new (this) Event(q, EventQueue::context31<F, B0, B1, B2, A0>(f, b0, b1, b2));
+    template <typename F, typename C0, typename C1, typename C2>
+    Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2) {
+        new (this) Event(q, EventQueue::context31<F, C0, C1, C2, A0>(f, c0, c1, c2));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1, typename B2, typename B3>
-    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3) {
-        new (this) Event(q, EventQueue::context41<F, B0, B1, B2, B3, A0>(f, b0, b1, b2, b3));
+    template <typename F, typename C0, typename C1, typename C2, typename C3>
+    Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3) {
+        new (this) Event(q, EventQueue::context41<F, C0, C1, C2, C3, A0>(f, c0, c1, c2, c3));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1, typename B2, typename B3, typename B4>
-    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
-        new (this) Event(q, EventQueue::context51<F, B0, B1, B2, B3, B4, A0>(f, b0, b1, b2, b3, b4));
+    template <typename F, typename C0, typename C1, typename C2, typename C3, typename C4>
+    Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+        new (this) Event(q, EventQueue::context51<F, C0, C1, C2, C3, C4, A0>(f, c0, c1, c2, c3, c4));
     }
 
     /** Create an event
@@ -1018,41 +1018,41 @@ public:
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0>
-    Event(EventQueue *q, F f, B0 b0) {
-        new (this) Event(q, EventQueue::context12<F, B0, A0, A1>(f, b0));
+    template <typename F, typename C0>
+    Event(EventQueue *q, F f, C0 c0) {
+        new (this) Event(q, EventQueue::context12<F, C0, A0, A1>(f, c0));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1>
-    Event(EventQueue *q, F f, B0 b0, B1 b1) {
-        new (this) Event(q, EventQueue::context22<F, B0, B1, A0, A1>(f, b0, b1));
+    template <typename F, typename C0, typename C1>
+    Event(EventQueue *q, F f, C0 c0, C1 c1) {
+        new (this) Event(q, EventQueue::context22<F, C0, C1, A0, A1>(f, c0, c1));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1, typename B2>
-    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2) {
-        new (this) Event(q, EventQueue::context32<F, B0, B1, B2, A0, A1>(f, b0, b1, b2));
+    template <typename F, typename C0, typename C1, typename C2>
+    Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2) {
+        new (this) Event(q, EventQueue::context32<F, C0, C1, C2, A0, A1>(f, c0, c1, c2));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1, typename B2, typename B3>
-    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3) {
-        new (this) Event(q, EventQueue::context42<F, B0, B1, B2, B3, A0, A1>(f, b0, b1, b2, b3));
+    template <typename F, typename C0, typename C1, typename C2, typename C3>
+    Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3) {
+        new (this) Event(q, EventQueue::context42<F, C0, C1, C2, C3, A0, A1>(f, c0, c1, c2, c3));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1, typename B2, typename B3, typename B4>
-    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
-        new (this) Event(q, EventQueue::context52<F, B0, B1, B2, B3, B4, A0, A1>(f, b0, b1, b2, b3, b4));
+    template <typename F, typename C0, typename C1, typename C2, typename C3, typename C4>
+    Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+        new (this) Event(q, EventQueue::context52<F, C0, C1, C2, C3, C4, A0, A1>(f, c0, c1, c2, c3, c4));
     }
 
     /** Create an event
@@ -1414,41 +1414,41 @@ public:
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0>
-    Event(EventQueue *q, F f, B0 b0) {
-        new (this) Event(q, EventQueue::context13<F, B0, A0, A1, A2>(f, b0));
+    template <typename F, typename C0>
+    Event(EventQueue *q, F f, C0 c0) {
+        new (this) Event(q, EventQueue::context13<F, C0, A0, A1, A2>(f, c0));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1>
-    Event(EventQueue *q, F f, B0 b0, B1 b1) {
-        new (this) Event(q, EventQueue::context23<F, B0, B1, A0, A1, A2>(f, b0, b1));
+    template <typename F, typename C0, typename C1>
+    Event(EventQueue *q, F f, C0 c0, C1 c1) {
+        new (this) Event(q, EventQueue::context23<F, C0, C1, A0, A1, A2>(f, c0, c1));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1, typename B2>
-    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2) {
-        new (this) Event(q, EventQueue::context33<F, B0, B1, B2, A0, A1, A2>(f, b0, b1, b2));
+    template <typename F, typename C0, typename C1, typename C2>
+    Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2) {
+        new (this) Event(q, EventQueue::context33<F, C0, C1, C2, A0, A1, A2>(f, c0, c1, c2));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1, typename B2, typename B3>
-    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3) {
-        new (this) Event(q, EventQueue::context43<F, B0, B1, B2, B3, A0, A1, A2>(f, b0, b1, b2, b3));
+    template <typename F, typename C0, typename C1, typename C2, typename C3>
+    Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3) {
+        new (this) Event(q, EventQueue::context43<F, C0, C1, C2, C3, A0, A1, A2>(f, c0, c1, c2, c3));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1, typename B2, typename B3, typename B4>
-    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
-        new (this) Event(q, EventQueue::context53<F, B0, B1, B2, B3, B4, A0, A1, A2>(f, b0, b1, b2, b3, b4));
+    template <typename F, typename C0, typename C1, typename C2, typename C3, typename C4>
+    Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+        new (this) Event(q, EventQueue::context53<F, C0, C1, C2, C3, C4, A0, A1, A2>(f, c0, c1, c2, c3, c4));
     }
 
     /** Create an event
@@ -1810,41 +1810,41 @@ public:
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0>
-    Event(EventQueue *q, F f, B0 b0) {
-        new (this) Event(q, EventQueue::context14<F, B0, A0, A1, A2, A3>(f, b0));
+    template <typename F, typename C0>
+    Event(EventQueue *q, F f, C0 c0) {
+        new (this) Event(q, EventQueue::context14<F, C0, A0, A1, A2, A3>(f, c0));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1>
-    Event(EventQueue *q, F f, B0 b0, B1 b1) {
-        new (this) Event(q, EventQueue::context24<F, B0, B1, A0, A1, A2, A3>(f, b0, b1));
+    template <typename F, typename C0, typename C1>
+    Event(EventQueue *q, F f, C0 c0, C1 c1) {
+        new (this) Event(q, EventQueue::context24<F, C0, C1, A0, A1, A2, A3>(f, c0, c1));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1, typename B2>
-    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2) {
-        new (this) Event(q, EventQueue::context34<F, B0, B1, B2, A0, A1, A2, A3>(f, b0, b1, b2));
+    template <typename F, typename C0, typename C1, typename C2>
+    Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2) {
+        new (this) Event(q, EventQueue::context34<F, C0, C1, C2, A0, A1, A2, A3>(f, c0, c1, c2));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1, typename B2, typename B3>
-    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3) {
-        new (this) Event(q, EventQueue::context44<F, B0, B1, B2, B3, A0, A1, A2, A3>(f, b0, b1, b2, b3));
+    template <typename F, typename C0, typename C1, typename C2, typename C3>
+    Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3) {
+        new (this) Event(q, EventQueue::context44<F, C0, C1, C2, C3, A0, A1, A2, A3>(f, c0, c1, c2, c3));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1, typename B2, typename B3, typename B4>
-    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
-        new (this) Event(q, EventQueue::context54<F, B0, B1, B2, B3, B4, A0, A1, A2, A3>(f, b0, b1, b2, b3, b4));
+    template <typename F, typename C0, typename C1, typename C2, typename C3, typename C4>
+    Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+        new (this) Event(q, EventQueue::context54<F, C0, C1, C2, C3, C4, A0, A1, A2, A3>(f, c0, c1, c2, c3, c4));
     }
 
     /** Create an event
@@ -2206,41 +2206,41 @@ public:
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0>
-    Event(EventQueue *q, F f, B0 b0) {
-        new (this) Event(q, EventQueue::context15<F, B0, A0, A1, A2, A3, A4>(f, b0));
+    template <typename F, typename C0>
+    Event(EventQueue *q, F f, C0 c0) {
+        new (this) Event(q, EventQueue::context15<F, C0, A0, A1, A2, A3, A4>(f, c0));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1>
-    Event(EventQueue *q, F f, B0 b0, B1 b1) {
-        new (this) Event(q, EventQueue::context25<F, B0, B1, A0, A1, A2, A3, A4>(f, b0, b1));
+    template <typename F, typename C0, typename C1>
+    Event(EventQueue *q, F f, C0 c0, C1 c1) {
+        new (this) Event(q, EventQueue::context25<F, C0, C1, A0, A1, A2, A3, A4>(f, c0, c1));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1, typename B2>
-    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2) {
-        new (this) Event(q, EventQueue::context35<F, B0, B1, B2, A0, A1, A2, A3, A4>(f, b0, b1, b2));
+    template <typename F, typename C0, typename C1, typename C2>
+    Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2) {
+        new (this) Event(q, EventQueue::context35<F, C0, C1, C2, A0, A1, A2, A3, A4>(f, c0, c1, c2));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1, typename B2, typename B3>
-    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3) {
-        new (this) Event(q, EventQueue::context45<F, B0, B1, B2, B3, A0, A1, A2, A3, A4>(f, b0, b1, b2, b3));
+    template <typename F, typename C0, typename C1, typename C2, typename C3>
+    Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3) {
+        new (this) Event(q, EventQueue::context45<F, C0, C1, C2, C3, A0, A1, A2, A3, A4>(f, c0, c1, c2, c3));
     }
 
     /** Create an event
      *  @see Event::Event
      */
-    template <typename F, typename B0, typename B1, typename B2, typename B3, typename B4>
-    Event(EventQueue *q, F f, B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
-        new (this) Event(q, EventQueue::context55<F, B0, B1, B2, B3, B4, A0, A1, A2, A3, A4>(f, b0, b1, b2, b3, b4));
+    template <typename F, typename C0, typename C1, typename C2, typename C3, typename C4>
+    Event(EventQueue *q, F f, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+        new (this) Event(q, EventQueue::context55<F, C0, C1, C2, C3, C4, A0, A1, A2, A3, A4>(f, c0, c1, c2, c3, c4));
     }
 
     /** Create an event
@@ -2408,34 +2408,37 @@ public:
 
 // Convenience functions declared here to avoid cyclic
 // dependency between Event and EventQueue
-template <typename F>
-Event<void()> EventQueue::event(F f) {
-    return Event<void()>(this, f);
+template <typename R>
+Event<void()> EventQueue::event(R (*func)()) {
+    return Event<void()>(this, func);
 }
 
-template <typename F, typename A0>
-Event<void()> EventQueue::event(F f, A0 a0) {
-    return Event<void()>(this, f, a0);
+template <typename F, typename R>
+Event<void()> EventQueue::event(F func, typename detail::enable_if<
+            detail::is_type<R (F::*)(), &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func);
 }
 
-template <typename F, typename A0, typename A1>
-Event<void()> EventQueue::event(F f, A0 a0, A1 a1) {
-    return Event<void()>(this, f, a0, a1);
+template <typename F, typename R>
+Event<void()> EventQueue::event(const F func, typename detail::enable_if<
+            detail::is_type<R (F::*)() const, &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func);
 }
 
-template <typename F, typename A0, typename A1, typename A2>
-Event<void()> EventQueue::event(F f, A0 a0, A1 a1, A2 a2) {
-    return Event<void()>(this, f, a0, a1, a2);
+template <typename F, typename R>
+Event<void()> EventQueue::event(volatile F func, typename detail::enable_if<
+            detail::is_type<R (F::*)() volatile, &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func);
 }
 
-template <typename F, typename A0, typename A1, typename A2, typename A3>
-Event<void()> EventQueue::event(F f, A0 a0, A1 a1, A2 a2, A3 a3) {
-    return Event<void()>(this, f, a0, a1, a2, a3);
-}
-
-template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void()> EventQueue::event(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-    return Event<void()>(this, f, a0, a1, a2, a3, a4);
+template <typename F, typename R>
+Event<void()> EventQueue::event(const volatile F func, typename detail::enable_if<
+            detail::is_type<R (F::*)() const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func);
 }
 
 template <typename T, typename R>
@@ -2458,104 +2461,269 @@ Event<void()> EventQueue::event(const volatile T *obj, R (T::*method)() const vo
     return Event<void()>(this, mbed::callback(obj, method));
 }
 
-template <typename T, typename R, typename A0>
-Event<void()> EventQueue::event(T *obj, R (T::*method)(A0), A0 a0) {
-    return Event<void()>(this, mbed::callback(obj, method), a0);
+template <typename R, typename B0, typename C0>
+Event<void()> EventQueue::event(R (*func)(B0), C0 c0) {
+    return Event<void()>(this, func, c0);
 }
 
-template <typename T, typename R, typename A0>
-Event<void()> EventQueue::event(const T *obj, R (T::*method)(A0) const, A0 a0) {
-    return Event<void()>(this, mbed::callback(obj, method), a0);
+template <typename F, typename R, typename B0, typename C0>
+Event<void()> EventQueue::event(F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0), &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func, c0);
 }
 
-template <typename T, typename R, typename A0>
-Event<void()> EventQueue::event(volatile T *obj, R (T::*method)(A0) volatile, A0 a0) {
-    return Event<void()>(this, mbed::callback(obj, method), a0);
+template <typename F, typename R, typename B0, typename C0>
+Event<void()> EventQueue::event(const F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0) const, &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func, c0);
 }
 
-template <typename T, typename R, typename A0>
-Event<void()> EventQueue::event(const volatile T *obj, R (T::*method)(A0) const volatile, A0 a0) {
-    return Event<void()>(this, mbed::callback(obj, method), a0);
+template <typename F, typename R, typename B0, typename C0>
+Event<void()> EventQueue::event(volatile F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func, c0);
 }
 
-template <typename T, typename R, typename A0, typename A1>
-Event<void()> EventQueue::event(T *obj, R (T::*method)(A0, A1), A0 a0, A1 a1) {
-    return Event<void()>(this, mbed::callback(obj, method), a0, a1);
+template <typename F, typename R, typename B0, typename C0>
+Event<void()> EventQueue::event(const volatile F func, C0 c0, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func, c0);
 }
 
-template <typename T, typename R, typename A0, typename A1>
-Event<void()> EventQueue::event(const T *obj, R (T::*method)(A0, A1) const, A0 a0, A1 a1) {
-    return Event<void()>(this, mbed::callback(obj, method), a0, a1);
+template <typename T, typename R, typename B0, typename C0>
+Event<void()> EventQueue::event(T *obj, R (T::*method)(B0), C0 c0) {
+    return Event<void()>(this, mbed::callback(obj, method), c0);
 }
 
-template <typename T, typename R, typename A0, typename A1>
-Event<void()> EventQueue::event(volatile T *obj, R (T::*method)(A0, A1) volatile, A0 a0, A1 a1) {
-    return Event<void()>(this, mbed::callback(obj, method), a0, a1);
+template <typename T, typename R, typename B0, typename C0>
+Event<void()> EventQueue::event(const T *obj, R (T::*method)(B0) const, C0 c0) {
+    return Event<void()>(this, mbed::callback(obj, method), c0);
 }
 
-template <typename T, typename R, typename A0, typename A1>
-Event<void()> EventQueue::event(const volatile T *obj, R (T::*method)(A0, A1) const volatile, A0 a0, A1 a1) {
-    return Event<void()>(this, mbed::callback(obj, method), a0, a1);
+template <typename T, typename R, typename B0, typename C0>
+Event<void()> EventQueue::event(volatile T *obj, R (T::*method)(B0) volatile, C0 c0) {
+    return Event<void()>(this, mbed::callback(obj, method), c0);
 }
 
-template <typename T, typename R, typename A0, typename A1, typename A2>
-Event<void()> EventQueue::event(T *obj, R (T::*method)(A0, A1, A2), A0 a0, A1 a1, A2 a2) {
-    return Event<void()>(this, mbed::callback(obj, method), a0, a1, a2);
+template <typename T, typename R, typename B0, typename C0>
+Event<void()> EventQueue::event(const volatile T *obj, R (T::*method)(B0) const volatile, C0 c0) {
+    return Event<void()>(this, mbed::callback(obj, method), c0);
 }
 
-template <typename T, typename R, typename A0, typename A1, typename A2>
-Event<void()> EventQueue::event(const T *obj, R (T::*method)(A0, A1, A2) const, A0 a0, A1 a1, A2 a2) {
-    return Event<void()>(this, mbed::callback(obj, method), a0, a1, a2);
+template <typename R, typename B0, typename B1, typename C0, typename C1>
+Event<void()> EventQueue::event(R (*func)(B0, B1), C0 c0, C1 c1) {
+    return Event<void()>(this, func, c0, c1);
 }
 
-template <typename T, typename R, typename A0, typename A1, typename A2>
-Event<void()> EventQueue::event(volatile T *obj, R (T::*method)(A0, A1, A2) volatile, A0 a0, A1 a1, A2 a2) {
-    return Event<void()>(this, mbed::callback(obj, method), a0, a1, a2);
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1>
+Event<void()> EventQueue::event(F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1), &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func, c0, c1);
 }
 
-template <typename T, typename R, typename A0, typename A1, typename A2>
-Event<void()> EventQueue::event(const volatile T *obj, R (T::*method)(A0, A1, A2) const volatile, A0 a0, A1 a1, A2 a2) {
-    return Event<void()>(this, mbed::callback(obj, method), a0, a1, a2);
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1>
+Event<void()> EventQueue::event(const F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1) const, &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func, c0, c1);
 }
 
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-Event<void()> EventQueue::event(T *obj, R (T::*method)(A0, A1, A2, A3), A0 a0, A1 a1, A2 a2, A3 a3) {
-    return Event<void()>(this, mbed::callback(obj, method), a0, a1, a2, a3);
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1>
+Event<void()> EventQueue::event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func, c0, c1);
 }
 
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-Event<void()> EventQueue::event(const T *obj, R (T::*method)(A0, A1, A2, A3) const, A0 a0, A1 a1, A2 a2, A3 a3) {
-    return Event<void()>(this, mbed::callback(obj, method), a0, a1, a2, a3);
+template <typename F, typename R, typename B0, typename B1, typename C0, typename C1>
+Event<void()> EventQueue::event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func, c0, c1);
 }
 
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-Event<void()> EventQueue::event(volatile T *obj, R (T::*method)(A0, A1, A2, A3) volatile, A0 a0, A1 a1, A2 a2, A3 a3) {
-    return Event<void()>(this, mbed::callback(obj, method), a0, a1, a2, a3);
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1>
+Event<void()> EventQueue::event(T *obj, R (T::*method)(B0, B1), C0 c0, C1 c1) {
+    return Event<void()>(this, mbed::callback(obj, method), c0, c1);
 }
 
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-Event<void()> EventQueue::event(const volatile T *obj, R (T::*method)(A0, A1, A2, A3) const volatile, A0 a0, A1 a1, A2 a2, A3 a3) {
-    return Event<void()>(this, mbed::callback(obj, method), a0, a1, a2, a3);
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1>
+Event<void()> EventQueue::event(const T *obj, R (T::*method)(B0, B1) const, C0 c0, C1 c1) {
+    return Event<void()>(this, mbed::callback(obj, method), c0, c1);
 }
 
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void()> EventQueue::event(T *obj, R (T::*method)(A0, A1, A2, A3, A4), A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-    return Event<void()>(this, mbed::callback(obj, method), a0, a1, a2, a3, a4);
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1>
+Event<void()> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1) volatile, C0 c0, C1 c1) {
+    return Event<void()>(this, mbed::callback(obj, method), c0, c1);
 }
 
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void()> EventQueue::event(const T *obj, R (T::*method)(A0, A1, A2, A3, A4) const, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-    return Event<void()>(this, mbed::callback(obj, method), a0, a1, a2, a3, a4);
+template <typename T, typename R, typename B0, typename B1, typename C0, typename C1>
+Event<void()> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1) const volatile, C0 c0, C1 c1) {
+    return Event<void()>(this, mbed::callback(obj, method), c0, c1);
 }
 
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void()> EventQueue::event(volatile T *obj, R (T::*method)(A0, A1, A2, A3, A4) volatile, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-    return Event<void()>(this, mbed::callback(obj, method), a0, a1, a2, a3, a4);
+template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
+Event<void()> EventQueue::event(R (*func)(B0, B1, B2), C0 c0, C1 c1, C2 c2) {
+    return Event<void()>(this, func, c0, c1, c2);
 }
 
-template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void()> EventQueue::event(const volatile T *obj, R (T::*method)(A0, A1, A2, A3, A4) const volatile, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
-    return Event<void()>(this, mbed::callback(obj, method), a0, a1, a2, a3, a4);
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
+Event<void()> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2), &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
+Event<void()> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2) const, &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
+Event<void()> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func, c0, c1, c2);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
+Event<void()> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func, c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
+Event<void()> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2), C0 c0, C1 c1, C2 c2) {
+    return Event<void()>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
+Event<void()> EventQueue::event(const T *obj, R (T::*method)(B0, B1, B2) const, C0 c0, C1 c1, C2 c2) {
+    return Event<void()>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
+Event<void()> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2) volatile, C0 c0, C1 c1, C2 c2) {
+    return Event<void()>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
+Event<void()> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2) const volatile, C0 c0, C1 c1, C2 c2) {
+    return Event<void()>(this, mbed::callback(obj, method), c0, c1, c2);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
+Event<void()> EventQueue::event(R (*func)(B0, B1, B2, B3), C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void()>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
+Event<void()> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3), &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
+Event<void()> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3) const, &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
+Event<void()> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func, c0, c1, c2, c3);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
+Event<void()> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func, c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
+Event<void()> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, B3), C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void()>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
+Event<void()> EventQueue::event(const T *obj, R (T::*method)(B0, B1, B2, B3) const, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void()>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
+Event<void()> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2, B3) volatile, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void()>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
+Event<void()> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3) const volatile, C0 c0, C1 c1, C2 c2, C3 c3) {
+    return Event<void()>(this, mbed::callback(obj, method), c0, c1, c2, c3);
+}
+
+template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
+Event<void()> EventQueue::event(R (*func)(B0, B1, B2, B3, B4), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void()>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
+Event<void()> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4), &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
+Event<void()> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4) const, &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
+Event<void()> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4) volatile, &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
+Event<void()> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+            detail::is_type<R (F::*)(B0, B1, B2, B3, B4) const volatile, &F::operator()>::value
+        >::type) {
+    return Event<void()>(this, func, c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
+Event<void()> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, B3, B4), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void()>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
+Event<void()> EventQueue::event(const T *obj, R (T::*method)(B0, B1, B2, B3, B4) const, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void()>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
+Event<void()> EventQueue::event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4) volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void()>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
+}
+
+template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
+Event<void()> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
+    return Event<void()>(this, mbed::callback(obj, method), c0, c1, c2, c3, c4);
 }
 
 }

--- a/EventQueue.h
+++ b/EventQueue.h
@@ -1349,6 +1349,1866 @@ public:
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
     Event<void()> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename A0>
+    Event<void(A0)> event(R (*func)(A0));
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename A0>
+    Event<void(A0)> event(F func, typename detail::enable_if<
+                detail::is_type<R (F::*)(A0), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename A0>
+    Event<void(A0)> event(const F func, typename detail::enable_if<
+                detail::is_type<R (F::*)(A0) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename A0>
+    Event<void(A0)> event(volatile F func, typename detail::enable_if<
+                detail::is_type<R (F::*)(A0) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename A0>
+    Event<void(A0)> event(const volatile F func, typename detail::enable_if<
+                detail::is_type<R (F::*)(A0) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename A0>
+    Event<void(A0)> event(T *obj, R (T::*method)(A0));
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename A0>
+    Event<void(A0)> event(const T *obj, R (T::*method)(A0) const);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename A0>
+    Event<void(A0)> event(volatile T *obj, R (T::*method)(A0) volatile);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename A0>
+    Event<void(A0)> event(const volatile T *obj, R (T::*method)(A0) const volatile);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename C0, typename A0>
+    Event<void(A0)> event(R (*func)(B0, A0), C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename C0, typename A0>
+    Event<void(A0)> event(F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, A0), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename C0, typename A0>
+    Event<void(A0)> event(const F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, A0) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename C0, typename A0>
+    Event<void(A0)> event(volatile F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, A0) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename C0, typename A0>
+    Event<void(A0)> event(const volatile F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, A0) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename C0, typename A0>
+    Event<void(A0)> event(T *obj, R (T::*method)(B0, A0), C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename C0, typename A0>
+    Event<void(A0)> event(const T *obj, R (T::*method)(B0, A0) const, C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename C0, typename A0>
+    Event<void(A0)> event(volatile T *obj, R (T::*method)(B0, A0) volatile, C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename C0, typename A0>
+    Event<void(A0)> event(const volatile T *obj, R (T::*method)(B0, A0) const volatile, C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
+    Event<void(A0)> event(R (*func)(B0, B1, A0), C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
+    Event<void(A0)> event(F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, A0), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
+    Event<void(A0)> event(const F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, A0) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
+    Event<void(A0)> event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, A0) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
+    Event<void(A0)> event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, A0) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
+    Event<void(A0)> event(T *obj, R (T::*method)(B0, B1, A0), C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
+    Event<void(A0)> event(const T *obj, R (T::*method)(B0, B1, A0) const, C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
+    Event<void(A0)> event(volatile T *obj, R (T::*method)(B0, B1, A0) volatile, C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
+    Event<void(A0)> event(const volatile T *obj, R (T::*method)(B0, B1, A0) const volatile, C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
+    Event<void(A0)> event(R (*func)(B0, B1, B2, A0), C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
+    Event<void(A0)> event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, A0), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
+    Event<void(A0)> event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, A0) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
+    Event<void(A0)> event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, A0) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
+    Event<void(A0)> event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, A0) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
+    Event<void(A0)> event(T *obj, R (T::*method)(B0, B1, B2, A0), C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
+    Event<void(A0)> event(const T *obj, R (T::*method)(B0, B1, B2, A0) const, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
+    Event<void(A0)> event(volatile T *obj, R (T::*method)(B0, B1, B2, A0) volatile, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
+    Event<void(A0)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0) const volatile, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
+    Event<void(A0)> event(R (*func)(B0, B1, B2, B3, A0), C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
+    Event<void(A0)> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, A0), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
+    Event<void(A0)> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, A0) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
+    Event<void(A0)> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, A0) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
+    Event<void(A0)> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, A0) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
+    Event<void(A0)> event(T *obj, R (T::*method)(B0, B1, B2, B3, A0), C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
+    Event<void(A0)> event(const T *obj, R (T::*method)(B0, B1, B2, B3, A0) const, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
+    Event<void(A0)> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0) volatile, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
+    Event<void(A0)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0) const volatile, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
+    Event<void(A0)> event(R (*func)(B0, B1, B2, B3, B4, A0), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
+    Event<void(A0)> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
+    Event<void(A0)> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
+    Event<void(A0)> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
+    Event<void(A0)> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
+    Event<void(A0)> event(T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
+    Event<void(A0)> event(const T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0) const, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
+    Event<void(A0)> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0) volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
+    Event<void(A0)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename A0, typename A1>
+    Event<void(A0, A1)> event(R (*func)(A0, A1));
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename A0, typename A1>
+    Event<void(A0, A1)> event(F func, typename detail::enable_if<
+                detail::is_type<R (F::*)(A0, A1), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename A0, typename A1>
+    Event<void(A0, A1)> event(const F func, typename detail::enable_if<
+                detail::is_type<R (F::*)(A0, A1) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename A0, typename A1>
+    Event<void(A0, A1)> event(volatile F func, typename detail::enable_if<
+                detail::is_type<R (F::*)(A0, A1) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename A0, typename A1>
+    Event<void(A0, A1)> event(const volatile F func, typename detail::enable_if<
+                detail::is_type<R (F::*)(A0, A1) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename A0, typename A1>
+    Event<void(A0, A1)> event(T *obj, R (T::*method)(A0, A1));
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename A0, typename A1>
+    Event<void(A0, A1)> event(const T *obj, R (T::*method)(A0, A1) const);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename A0, typename A1>
+    Event<void(A0, A1)> event(volatile T *obj, R (T::*method)(A0, A1) volatile);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename A0, typename A1>
+    Event<void(A0, A1)> event(const volatile T *obj, R (T::*method)(A0, A1) const volatile);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename C0, typename A0, typename A1>
+    Event<void(A0, A1)> event(R (*func)(B0, A0, A1), C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1>
+    Event<void(A0, A1)> event(F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, A0, A1), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1>
+    Event<void(A0, A1)> event(const F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, A0, A1) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1>
+    Event<void(A0, A1)> event(volatile F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, A0, A1) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1>
+    Event<void(A0, A1)> event(const volatile F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, A0, A1) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename C0, typename A0, typename A1>
+    Event<void(A0, A1)> event(T *obj, R (T::*method)(B0, A0, A1), C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename C0, typename A0, typename A1>
+    Event<void(A0, A1)> event(const T *obj, R (T::*method)(B0, A0, A1) const, C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename C0, typename A0, typename A1>
+    Event<void(A0, A1)> event(volatile T *obj, R (T::*method)(B0, A0, A1) volatile, C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename C0, typename A0, typename A1>
+    Event<void(A0, A1)> event(const volatile T *obj, R (T::*method)(B0, A0, A1) const volatile, C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
+    Event<void(A0, A1)> event(R (*func)(B0, B1, A0, A1), C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
+    Event<void(A0, A1)> event(F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, A0, A1), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
+    Event<void(A0, A1)> event(const F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, A0, A1) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
+    Event<void(A0, A1)> event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, A0, A1) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
+    Event<void(A0, A1)> event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, A0, A1) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
+    Event<void(A0, A1)> event(T *obj, R (T::*method)(B0, B1, A0, A1), C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
+    Event<void(A0, A1)> event(const T *obj, R (T::*method)(B0, B1, A0, A1) const, C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
+    Event<void(A0, A1)> event(volatile T *obj, R (T::*method)(B0, B1, A0, A1) volatile, C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
+    Event<void(A0, A1)> event(const volatile T *obj, R (T::*method)(B0, B1, A0, A1) const volatile, C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
+    Event<void(A0, A1)> event(R (*func)(B0, B1, B2, A0, A1), C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
+    Event<void(A0, A1)> event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, A0, A1), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
+    Event<void(A0, A1)> event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, A0, A1) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
+    Event<void(A0, A1)> event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, A0, A1) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
+    Event<void(A0, A1)> event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, A0, A1) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
+    Event<void(A0, A1)> event(T *obj, R (T::*method)(B0, B1, B2, A0, A1), C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
+    Event<void(A0, A1)> event(const T *obj, R (T::*method)(B0, B1, B2, A0, A1) const, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
+    Event<void(A0, A1)> event(volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1) volatile, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
+    Event<void(A0, A1)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1) const volatile, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
+    Event<void(A0, A1)> event(R (*func)(B0, B1, B2, B3, A0, A1), C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
+    Event<void(A0, A1)> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
+    Event<void(A0, A1)> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
+    Event<void(A0, A1)> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
+    Event<void(A0, A1)> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
+    Event<void(A0, A1)> event(T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1), C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
+    Event<void(A0, A1)> event(const T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1) const, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
+    Event<void(A0, A1)> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1) volatile, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
+    Event<void(A0, A1)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1) const volatile, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
+    Event<void(A0, A1)> event(R (*func)(B0, B1, B2, B3, B4, A0, A1), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
+    Event<void(A0, A1)> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
+    Event<void(A0, A1)> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
+    Event<void(A0, A1)> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
+    Event<void(A0, A1)> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
+    Event<void(A0, A1)> event(T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
+    Event<void(A0, A1)> event(const T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1) const, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
+    Event<void(A0, A1)> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1) volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
+    Event<void(A0, A1)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(R (*func)(A0, A1, A2));
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(F func, typename detail::enable_if<
+                detail::is_type<R (F::*)(A0, A1, A2), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const F func, typename detail::enable_if<
+                detail::is_type<R (F::*)(A0, A1, A2) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(volatile F func, typename detail::enable_if<
+                detail::is_type<R (F::*)(A0, A1, A2) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const volatile F func, typename detail::enable_if<
+                detail::is_type<R (F::*)(A0, A1, A2) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(T *obj, R (T::*method)(A0, A1, A2));
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const T *obj, R (T::*method)(A0, A1, A2) const);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(volatile T *obj, R (T::*method)(A0, A1, A2) volatile);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const volatile T *obj, R (T::*method)(A0, A1, A2) const volatile);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(R (*func)(B0, A0, A1, A2), C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, A0, A1, A2), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, A0, A1, A2) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(volatile F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, A0, A1, A2) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const volatile F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, A0, A1, A2) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(T *obj, R (T::*method)(B0, A0, A1, A2), C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const T *obj, R (T::*method)(B0, A0, A1, A2) const, C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(volatile T *obj, R (T::*method)(B0, A0, A1, A2) volatile, C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const volatile T *obj, R (T::*method)(B0, A0, A1, A2) const volatile, C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(R (*func)(B0, B1, A0, A1, A2), C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, A0, A1, A2), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, A0, A1, A2) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, A0, A1, A2) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, A0, A1, A2) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(T *obj, R (T::*method)(B0, B1, A0, A1, A2), C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const T *obj, R (T::*method)(B0, B1, A0, A1, A2) const, C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(volatile T *obj, R (T::*method)(B0, B1, A0, A1, A2) volatile, C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const volatile T *obj, R (T::*method)(B0, B1, A0, A1, A2) const volatile, C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(R (*func)(B0, B1, B2, A0, A1, A2), C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2), C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2) const, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2) volatile, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2) const volatile, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(R (*func)(B0, B1, B2, B3, A0, A1, A2), C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2), C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2) const, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2) volatile, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2) const volatile, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(R (*func)(B0, B1, B2, B3, B4, A0, A1, A2), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2) const, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2) volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
+    Event<void(A0, A1, A2)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(R (*func)(A0, A1, A2, A3));
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(F func, typename detail::enable_if<
+                detail::is_type<R (F::*)(A0, A1, A2, A3), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const F func, typename detail::enable_if<
+                detail::is_type<R (F::*)(A0, A1, A2, A3) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(volatile F func, typename detail::enable_if<
+                detail::is_type<R (F::*)(A0, A1, A2, A3) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const volatile F func, typename detail::enable_if<
+                detail::is_type<R (F::*)(A0, A1, A2, A3) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(T *obj, R (T::*method)(A0, A1, A2, A3));
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const T *obj, R (T::*method)(A0, A1, A2, A3) const);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(volatile T *obj, R (T::*method)(A0, A1, A2, A3) volatile);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const volatile T *obj, R (T::*method)(A0, A1, A2, A3) const volatile);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(R (*func)(B0, A0, A1, A2, A3), C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, A0, A1, A2, A3), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, A0, A1, A2, A3) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(volatile F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, A0, A1, A2, A3) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const volatile F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, A0, A1, A2, A3) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(T *obj, R (T::*method)(B0, A0, A1, A2, A3), C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const T *obj, R (T::*method)(B0, A0, A1, A2, A3) const, C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(volatile T *obj, R (T::*method)(B0, A0, A1, A2, A3) volatile, C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const volatile T *obj, R (T::*method)(B0, A0, A1, A2, A3) const volatile, C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(R (*func)(B0, B1, A0, A1, A2, A3), C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3), C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3) const, C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(volatile T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3) volatile, C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const volatile T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3) const volatile, C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(R (*func)(B0, B1, B2, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3) const, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3) volatile, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3) const volatile, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(R (*func)(B0, B1, B2, B3, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3) const, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3) volatile, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3) const volatile, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(R (*func)(B0, B1, B2, B3, B4, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3) const, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3) volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
+    Event<void(A0, A1, A2, A3)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(R (*func)(A0, A1, A2, A3, A4));
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(F func, typename detail::enable_if<
+                detail::is_type<R (F::*)(A0, A1, A2, A3, A4), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const F func, typename detail::enable_if<
+                detail::is_type<R (F::*)(A0, A1, A2, A3, A4) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(volatile F func, typename detail::enable_if<
+                detail::is_type<R (F::*)(A0, A1, A2, A3, A4) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const volatile F func, typename detail::enable_if<
+                detail::is_type<R (F::*)(A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(T *obj, R (T::*method)(A0, A1, A2, A3, A4));
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const T *obj, R (T::*method)(A0, A1, A2, A3, A4) const);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(volatile T *obj, R (T::*method)(A0, A1, A2, A3, A4) volatile);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const volatile T *obj, R (T::*method)(A0, A1, A2, A3, A4) const volatile);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(R (*func)(B0, A0, A1, A2, A3, A4), C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, A0, A1, A2, A3, A4), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, A0, A1, A2, A3, A4) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(volatile F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, A0, A1, A2, A3, A4) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const volatile F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(T *obj, R (T::*method)(B0, A0, A1, A2, A3, A4), C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const T *obj, R (T::*method)(B0, A0, A1, A2, A3, A4) const, C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(volatile T *obj, R (T::*method)(B0, A0, A1, A2, A3, A4) volatile, C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const volatile T *obj, R (T::*method)(B0, A0, A1, A2, A3, A4) const volatile, C0 c0);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(R (*func)(B0, B1, A0, A1, A2, A3, A4), C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3, A4), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3, A4) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3, A4) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3, A4), C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3, A4) const, C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(volatile T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3, A4) volatile, C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const volatile T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3, A4) const volatile, C0 c0, C1 c1);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(R (*func)(B0, B1, B2, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3, A4), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3, A4) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3, A4) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3, A4) const, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3, A4) volatile, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3, A4) const volatile, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(R (*func)(B0, B1, B2, B3, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3, A4), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3, A4) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3, A4) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3, A4) const, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3, A4) volatile, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3, A4) const volatile, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(R (*func)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) const, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
+    Event<void(A0, A1, A2, A3, A4)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
 protected:
     template <typename F>
     friend class Event;

--- a/EventQueue.h
+++ b/EventQueue.h
@@ -40,6 +40,26 @@ namespace events {
 template <typename F>
 class Event;
 
+// Internal sfinae declarations
+//
+// These are used to eliminate overloads based on member function types.
+// Handled cleanly by the compiler, these avoid massive and misleading error
+// messages when confronted with an invalid type (or worse, runtime failures)
+namespace detail {
+    struct nil {};
+
+    template <bool B, typename R = nil>
+    struct enable_if { typedef R type; };
+
+    template <typename R>
+    struct enable_if<false, R> {};
+
+    template <typename M, M>
+    struct is_type {
+        static const bool value = true;
+    };
+}
+
 
 /** EventQueue
  *
@@ -960,38 +980,40 @@ public:
      *  @param a0..a4   Arguments to pass to the callback
      *  @return         Event that will dispatch on the specific queue
      */
-    template <typename F>
-    Event<void()> event(F f);
+    template <typename R>
+    Event<void()> event(R (*func)());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename A0>
-    Event<void()> event(F f, A0 a0);
+    template <typename F, typename R>
+    Event<void()> event(F func, typename detail::enable_if<
+                detail::is_type<R (F::*)(), &F::operator()>::value
+            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename A0, typename A1>
-    Event<void()> event(F f, A0 a0, A1 a1);
+    template <typename F, typename R>
+    Event<void()> event(const F func, typename detail::enable_if<
+                detail::is_type<R (F::*)() const, &F::operator()>::value
+            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename A0, typename A1, typename A2>
-    Event<void()> event(F f, A0 a0, A1 a1, A2 a2);
+    template <typename F, typename R>
+    Event<void()> event(volatile F func, typename detail::enable_if<
+                detail::is_type<R (F::*)() volatile, &F::operator()>::value
+            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename A0, typename A1, typename A2, typename A3>
-    Event<void()> event(F f, A0 a0, A1 a1, A2 a2, A3 a3);
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void()> event(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4);
+    template <typename F, typename R>
+    Event<void()> event(const volatile F func, typename detail::enable_if<
+                detail::is_type<R (F::*)() const volatile, &F::operator()>::value
+            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1020,122 +1042,312 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename T, typename R, typename A0>
-    Event<void()> event(T *obj, R (T::*method)(A0), A0 a0);
+    template <typename R, typename B0, typename C0>
+    Event<void()> event(R (*func)(B0), C0 c0);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename T, typename R, typename A0>
-    Event<void()> event(const T *obj, R (T::*method)(A0) const, A0 a0);
+    template <typename F, typename R, typename B0, typename C0>
+    Event<void()> event(F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0), &F::operator()>::value
+            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename T, typename R, typename A0>
-    Event<void()> event(volatile T *obj, R (T::*method)(A0) volatile, A0 a0);
+    template <typename F, typename R, typename B0, typename C0>
+    Event<void()> event(const F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0) const, &F::operator()>::value
+            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename T, typename R, typename A0>
-    Event<void()> event(const volatile T *obj, R (T::*method)(A0) const volatile, A0 a0);
+    template <typename F, typename R, typename B0, typename C0>
+    Event<void()> event(volatile F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0) volatile, &F::operator()>::value
+            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename T, typename R, typename A0, typename A1>
-    Event<void()> event(T *obj, R (T::*method)(A0, A1), A0 a0, A1 a1);
+    template <typename F, typename R, typename B0, typename C0>
+    Event<void()> event(const volatile F func, C0 c0, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0) const volatile, &F::operator()>::value
+            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename T, typename R, typename A0, typename A1>
-    Event<void()> event(const T *obj, R (T::*method)(A0, A1) const, A0 a0, A1 a1);
+    template <typename T, typename R, typename B0, typename C0>
+    Event<void()> event(T *obj, R (T::*method)(B0), C0 c0);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename T, typename R, typename A0, typename A1>
-    Event<void()> event(volatile T *obj, R (T::*method)(A0, A1) volatile, A0 a0, A1 a1);
+    template <typename T, typename R, typename B0, typename C0>
+    Event<void()> event(const T *obj, R (T::*method)(B0) const, C0 c0);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename T, typename R, typename A0, typename A1>
-    Event<void()> event(const volatile T *obj, R (T::*method)(A0, A1) const volatile, A0 a0, A1 a1);
+    template <typename T, typename R, typename B0, typename C0>
+    Event<void()> event(volatile T *obj, R (T::*method)(B0) volatile, C0 c0);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename T, typename R, typename A0, typename A1, typename A2>
-    Event<void()> event(T *obj, R (T::*method)(A0, A1, A2), A0 a0, A1 a1, A2 a2);
+    template <typename T, typename R, typename B0, typename C0>
+    Event<void()> event(const volatile T *obj, R (T::*method)(B0) const volatile, C0 c0);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename T, typename R, typename A0, typename A1, typename A2>
-    Event<void()> event(const T *obj, R (T::*method)(A0, A1, A2) const, A0 a0, A1 a1, A2 a2);
+    template <typename R, typename B0, typename B1, typename C0, typename C1>
+    Event<void()> event(R (*func)(B0, B1), C0 c0, C1 c1);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename T, typename R, typename A0, typename A1, typename A2>
-    Event<void()> event(volatile T *obj, R (T::*method)(A0, A1, A2) volatile, A0 a0, A1 a1, A2 a2);
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1>
+    Event<void()> event(F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1), &F::operator()>::value
+            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename T, typename R, typename A0, typename A1, typename A2>
-    Event<void()> event(const volatile T *obj, R (T::*method)(A0, A1, A2) const volatile, A0 a0, A1 a1, A2 a2);
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1>
+    Event<void()> event(const F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1) const, &F::operator()>::value
+            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-    Event<void()> event(T *obj, R (T::*method)(A0, A1, A2, A3), A0 a0, A1 a1, A2 a2, A3 a3);
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1>
+    Event<void()> event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1) volatile, &F::operator()>::value
+            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-    Event<void()> event(const T *obj, R (T::*method)(A0, A1, A2, A3) const, A0 a0, A1 a1, A2 a2, A3 a3);
+    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1>
+    Event<void()> event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1) const volatile, &F::operator()>::value
+            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-    Event<void()> event(volatile T *obj, R (T::*method)(A0, A1, A2, A3) volatile, A0 a0, A1 a1, A2 a2, A3 a3);
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1>
+    Event<void()> event(T *obj, R (T::*method)(B0, B1), C0 c0, C1 c1);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
-    Event<void()> event(const volatile T *obj, R (T::*method)(A0, A1, A2, A3) const volatile, A0 a0, A1 a1, A2 a2, A3 a3);
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1>
+    Event<void()> event(const T *obj, R (T::*method)(B0, B1) const, C0 c0, C1 c1);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void()> event(T *obj, R (T::*method)(A0, A1, A2, A3, A4), A0 a0, A1 a1, A2 a2, A3 a3, A4 a4);
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1>
+    Event<void()> event(volatile T *obj, R (T::*method)(B0, B1) volatile, C0 c0, C1 c1);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void()> event(const T *obj, R (T::*method)(A0, A1, A2, A3, A4) const, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4);
+    template <typename T, typename R, typename B0, typename B1, typename C0, typename C1>
+    Event<void()> event(const volatile T *obj, R (T::*method)(B0, B1) const volatile, C0 c0, C1 c1);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void()> event(volatile T *obj, R (T::*method)(A0, A1, A2, A3, A4) volatile, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4);
+    template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
+    Event<void()> event(R (*func)(B0, B1, B2), C0 c0, C1 c1, C2 c2);
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void()> event(const volatile T *obj, R (T::*method)(A0, A1, A2, A3, A4) const volatile, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4);
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
+    Event<void()> event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
+    Event<void()> event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
+    Event<void()> event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
+    Event<void()> event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
+    Event<void()> event(T *obj, R (T::*method)(B0, B1, B2), C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
+    Event<void()> event(const T *obj, R (T::*method)(B0, B1, B2) const, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
+    Event<void()> event(volatile T *obj, R (T::*method)(B0, B1, B2) volatile, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
+    Event<void()> event(const volatile T *obj, R (T::*method)(B0, B1, B2) const volatile, C0 c0, C1 c1, C2 c2);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
+    Event<void()> event(R (*func)(B0, B1, B2, B3), C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
+    Event<void()> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
+    Event<void()> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
+    Event<void()> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
+    Event<void()> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
+    Event<void()> event(T *obj, R (T::*method)(B0, B1, B2, B3), C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
+    Event<void()> event(const T *obj, R (T::*method)(B0, B1, B2, B3) const, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
+    Event<void()> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3) volatile, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
+    Event<void()> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3) const volatile, C0 c0, C1 c1, C2 c2, C3 c3);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
+    Event<void()> event(R (*func)(B0, B1, B2, B3, B4), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
+    Event<void()> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4), &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
+    Event<void()> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4) const, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
+    Event<void()> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4) volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
+    Event<void()> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
+                detail::is_type<R (F::*)(B0, B1, B2, B3, B4) const volatile, &F::operator()>::value
+            >::type = detail::nil());
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
+    Event<void()> event(T *obj, R (T::*method)(B0, B1, B2, B3, B4), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
+    Event<void()> event(const T *obj, R (T::*method)(B0, B1, B2, B3, B4) const, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
+    Event<void()> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4) volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+
+    /** Creates an event bound to the event queue
+     *  @see EventQueue::event
+     */
+    template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
+    Event<void()> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
 protected:
     template <typename F>
@@ -1155,423 +1367,423 @@ protected:
         }
     };
 
-    template <typename F, typename A0>
+    template <typename F, typename C0>
     struct context10 {
-        F f; A0 a0;
+        F f; C0 c0;
 
-        context10(F f, A0 a0)
-            : f(f), a0(a0) {}
+        context10(F f, C0 c0)
+            : f(f), c0(c0) {}
 
         void operator()() {
-            f(a0);
+            f(c0);
         }
     };
 
-    template <typename F, typename A0, typename A1>
+    template <typename F, typename C0, typename C1>
     struct context20 {
-        F f; A0 a0; A1 a1;
+        F f; C0 c0; C1 c1;
 
-        context20(F f, A0 a0, A1 a1)
-            : f(f), a0(a0), a1(a1) {}
+        context20(F f, C0 c0, C1 c1)
+            : f(f), c0(c0), c1(c1) {}
 
         void operator()() {
-            f(a0, a1);
+            f(c0, c1);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename A2>
+    template <typename F, typename C0, typename C1, typename C2>
     struct context30 {
-        F f; A0 a0; A1 a1; A2 a2;
+        F f; C0 c0; C1 c1; C2 c2;
 
-        context30(F f, A0 a0, A1 a1, A2 a2)
-            : f(f), a0(a0), a1(a1), a2(a2) {}
+        context30(F f, C0 c0, C1 c1, C2 c2)
+            : f(f), c0(c0), c1(c1), c2(c2) {}
 
         void operator()() {
-            f(a0, a1, a2);
+            f(c0, c1, c2);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename A2, typename A3>
+    template <typename F, typename C0, typename C1, typename C2, typename C3>
     struct context40 {
-        F f; A0 a0; A1 a1; A2 a2; A3 a3;
+        F f; C0 c0; C1 c1; C2 c2; C3 c3;
 
-        context40(F f, A0 a0, A1 a1, A2 a2, A3 a3)
-            : f(f), a0(a0), a1(a1), a2(a2), a3(a3) {}
+        context40(F f, C0 c0, C1 c1, C2 c2, C3 c3)
+            : f(f), c0(c0), c1(c1), c2(c2), c3(c3) {}
 
         void operator()() {
-            f(a0, a1, a2, a3);
+            f(c0, c1, c2, c3);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
+    template <typename F, typename C0, typename C1, typename C2, typename C3, typename C4>
     struct context50 {
-        F f; A0 a0; A1 a1; A2 a2; A3 a3; A4 a4;
+        F f; C0 c0; C1 c1; C2 c2; C3 c3; C4 c4;
 
-        context50(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
-            : f(f), a0(a0), a1(a1), a2(a2), a3(a3), a4(a4) {}
+        context50(F f, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4)
+            : f(f), c0(c0), c1(c1), c2(c2), c3(c3), c4(c4) {}
 
         void operator()() {
-            f(a0, a1, a2, a3, a4);
+            f(c0, c1, c2, c3, c4);
         }
     };
 
-    template <typename F, typename B0>
+    template <typename F, typename A0>
     struct context01 {
         F f;
 
         context01(F f)
             : f(f) {}
 
-        void operator()(B0 b0) {
-            f(b0);
+        void operator()(A0 a0) {
+            f(a0);
         }
     };
 
-    template <typename F, typename A0, typename B0>
+    template <typename F, typename C0, typename A0>
     struct context11 {
-        F f; A0 a0;
+        F f; C0 c0;
 
-        context11(F f, A0 a0)
-            : f(f), a0(a0) {}
+        context11(F f, C0 c0)
+            : f(f), c0(c0) {}
 
-        void operator()(B0 b0) {
-            f(a0, b0);
+        void operator()(A0 a0) {
+            f(c0, a0);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename B0>
+    template <typename F, typename C0, typename C1, typename A0>
     struct context21 {
-        F f; A0 a0; A1 a1;
+        F f; C0 c0; C1 c1;
 
-        context21(F f, A0 a0, A1 a1)
-            : f(f), a0(a0), a1(a1) {}
+        context21(F f, C0 c0, C1 c1)
+            : f(f), c0(c0), c1(c1) {}
 
-        void operator()(B0 b0) {
-            f(a0, a1, b0);
+        void operator()(A0 a0) {
+            f(c0, c1, a0);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename A2, typename B0>
+    template <typename F, typename C0, typename C1, typename C2, typename A0>
     struct context31 {
-        F f; A0 a0; A1 a1; A2 a2;
+        F f; C0 c0; C1 c1; C2 c2;
 
-        context31(F f, A0 a0, A1 a1, A2 a2)
-            : f(f), a0(a0), a1(a1), a2(a2) {}
+        context31(F f, C0 c0, C1 c1, C2 c2)
+            : f(f), c0(c0), c1(c1), c2(c2) {}
 
-        void operator()(B0 b0) {
-            f(a0, a1, a2, b0);
+        void operator()(A0 a0) {
+            f(c0, c1, c2, a0);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename A2, typename A3, typename B0>
+    template <typename F, typename C0, typename C1, typename C2, typename C3, typename A0>
     struct context41 {
-        F f; A0 a0; A1 a1; A2 a2; A3 a3;
+        F f; C0 c0; C1 c1; C2 c2; C3 c3;
 
-        context41(F f, A0 a0, A1 a1, A2 a2, A3 a3)
-            : f(f), a0(a0), a1(a1), a2(a2), a3(a3) {}
+        context41(F f, C0 c0, C1 c1, C2 c2, C3 c3)
+            : f(f), c0(c0), c1(c1), c2(c2), c3(c3) {}
 
-        void operator()(B0 b0) {
-            f(a0, a1, a2, a3, b0);
+        void operator()(A0 a0) {
+            f(c0, c1, c2, c3, a0);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4, typename B0>
+    template <typename F, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
     struct context51 {
-        F f; A0 a0; A1 a1; A2 a2; A3 a3; A4 a4;
+        F f; C0 c0; C1 c1; C2 c2; C3 c3; C4 c4;
 
-        context51(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
-            : f(f), a0(a0), a1(a1), a2(a2), a3(a3), a4(a4) {}
+        context51(F f, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4)
+            : f(f), c0(c0), c1(c1), c2(c2), c3(c3), c4(c4) {}
 
-        void operator()(B0 b0) {
-            f(a0, a1, a2, a3, a4, b0);
+        void operator()(A0 a0) {
+            f(c0, c1, c2, c3, c4, a0);
         }
     };
 
-    template <typename F, typename B0, typename B1>
+    template <typename F, typename A0, typename A1>
     struct context02 {
         F f;
 
         context02(F f)
             : f(f) {}
 
-        void operator()(B0 b0, B1 b1) {
-            f(b0, b1);
+        void operator()(A0 a0, A1 a1) {
+            f(a0, a1);
         }
     };
 
-    template <typename F, typename A0, typename B0, typename B1>
+    template <typename F, typename C0, typename A0, typename A1>
     struct context12 {
-        F f; A0 a0;
+        F f; C0 c0;
 
-        context12(F f, A0 a0)
-            : f(f), a0(a0) {}
+        context12(F f, C0 c0)
+            : f(f), c0(c0) {}
 
-        void operator()(B0 b0, B1 b1) {
-            f(a0, b0, b1);
+        void operator()(A0 a0, A1 a1) {
+            f(c0, a0, a1);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename B0, typename B1>
+    template <typename F, typename C0, typename C1, typename A0, typename A1>
     struct context22 {
-        F f; A0 a0; A1 a1;
+        F f; C0 c0; C1 c1;
 
-        context22(F f, A0 a0, A1 a1)
-            : f(f), a0(a0), a1(a1) {}
+        context22(F f, C0 c0, C1 c1)
+            : f(f), c0(c0), c1(c1) {}
 
-        void operator()(B0 b0, B1 b1) {
-            f(a0, a1, b0, b1);
+        void operator()(A0 a0, A1 a1) {
+            f(c0, c1, a0, a1);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename A2, typename B0, typename B1>
+    template <typename F, typename C0, typename C1, typename C2, typename A0, typename A1>
     struct context32 {
-        F f; A0 a0; A1 a1; A2 a2;
+        F f; C0 c0; C1 c1; C2 c2;
 
-        context32(F f, A0 a0, A1 a1, A2 a2)
-            : f(f), a0(a0), a1(a1), a2(a2) {}
+        context32(F f, C0 c0, C1 c1, C2 c2)
+            : f(f), c0(c0), c1(c1), c2(c2) {}
 
-        void operator()(B0 b0, B1 b1) {
-            f(a0, a1, a2, b0, b1);
+        void operator()(A0 a0, A1 a1) {
+            f(c0, c1, c2, a0, a1);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename A2, typename A3, typename B0, typename B1>
+    template <typename F, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
     struct context42 {
-        F f; A0 a0; A1 a1; A2 a2; A3 a3;
+        F f; C0 c0; C1 c1; C2 c2; C3 c3;
 
-        context42(F f, A0 a0, A1 a1, A2 a2, A3 a3)
-            : f(f), a0(a0), a1(a1), a2(a2), a3(a3) {}
+        context42(F f, C0 c0, C1 c1, C2 c2, C3 c3)
+            : f(f), c0(c0), c1(c1), c2(c2), c3(c3) {}
 
-        void operator()(B0 b0, B1 b1) {
-            f(a0, a1, a2, a3, b0, b1);
+        void operator()(A0 a0, A1 a1) {
+            f(c0, c1, c2, c3, a0, a1);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4, typename B0, typename B1>
+    template <typename F, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
     struct context52 {
-        F f; A0 a0; A1 a1; A2 a2; A3 a3; A4 a4;
+        F f; C0 c0; C1 c1; C2 c2; C3 c3; C4 c4;
 
-        context52(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
-            : f(f), a0(a0), a1(a1), a2(a2), a3(a3), a4(a4) {}
+        context52(F f, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4)
+            : f(f), c0(c0), c1(c1), c2(c2), c3(c3), c4(c4) {}
 
-        void operator()(B0 b0, B1 b1) {
-            f(a0, a1, a2, a3, a4, b0, b1);
+        void operator()(A0 a0, A1 a1) {
+            f(c0, c1, c2, c3, c4, a0, a1);
         }
     };
 
-    template <typename F, typename B0, typename B1, typename B2>
+    template <typename F, typename A0, typename A1, typename A2>
     struct context03 {
         F f;
 
         context03(F f)
             : f(f) {}
 
-        void operator()(B0 b0, B1 b1, B2 b2) {
-            f(b0, b1, b2);
+        void operator()(A0 a0, A1 a1, A2 a2) {
+            f(a0, a1, a2);
         }
     };
 
-    template <typename F, typename A0, typename B0, typename B1, typename B2>
+    template <typename F, typename C0, typename A0, typename A1, typename A2>
     struct context13 {
-        F f; A0 a0;
+        F f; C0 c0;
 
-        context13(F f, A0 a0)
-            : f(f), a0(a0) {}
+        context13(F f, C0 c0)
+            : f(f), c0(c0) {}
 
-        void operator()(B0 b0, B1 b1, B2 b2) {
-            f(a0, b0, b1, b2);
+        void operator()(A0 a0, A1 a1, A2 a2) {
+            f(c0, a0, a1, a2);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename B0, typename B1, typename B2>
+    template <typename F, typename C0, typename C1, typename A0, typename A1, typename A2>
     struct context23 {
-        F f; A0 a0; A1 a1;
+        F f; C0 c0; C1 c1;
 
-        context23(F f, A0 a0, A1 a1)
-            : f(f), a0(a0), a1(a1) {}
+        context23(F f, C0 c0, C1 c1)
+            : f(f), c0(c0), c1(c1) {}
 
-        void operator()(B0 b0, B1 b1, B2 b2) {
-            f(a0, a1, b0, b1, b2);
+        void operator()(A0 a0, A1 a1, A2 a2) {
+            f(c0, c1, a0, a1, a2);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename A2, typename B0, typename B1, typename B2>
+    template <typename F, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
     struct context33 {
-        F f; A0 a0; A1 a1; A2 a2;
+        F f; C0 c0; C1 c1; C2 c2;
 
-        context33(F f, A0 a0, A1 a1, A2 a2)
-            : f(f), a0(a0), a1(a1), a2(a2) {}
+        context33(F f, C0 c0, C1 c1, C2 c2)
+            : f(f), c0(c0), c1(c1), c2(c2) {}
 
-        void operator()(B0 b0, B1 b1, B2 b2) {
-            f(a0, a1, a2, b0, b1, b2);
+        void operator()(A0 a0, A1 a1, A2 a2) {
+            f(c0, c1, c2, a0, a1, a2);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename A2, typename A3, typename B0, typename B1, typename B2>
+    template <typename F, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
     struct context43 {
-        F f; A0 a0; A1 a1; A2 a2; A3 a3;
+        F f; C0 c0; C1 c1; C2 c2; C3 c3;
 
-        context43(F f, A0 a0, A1 a1, A2 a2, A3 a3)
-            : f(f), a0(a0), a1(a1), a2(a2), a3(a3) {}
+        context43(F f, C0 c0, C1 c1, C2 c2, C3 c3)
+            : f(f), c0(c0), c1(c1), c2(c2), c3(c3) {}
 
-        void operator()(B0 b0, B1 b1, B2 b2) {
-            f(a0, a1, a2, a3, b0, b1, b2);
+        void operator()(A0 a0, A1 a1, A2 a2) {
+            f(c0, c1, c2, c3, a0, a1, a2);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4, typename B0, typename B1, typename B2>
+    template <typename F, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
     struct context53 {
-        F f; A0 a0; A1 a1; A2 a2; A3 a3; A4 a4;
+        F f; C0 c0; C1 c1; C2 c2; C3 c3; C4 c4;
 
-        context53(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
-            : f(f), a0(a0), a1(a1), a2(a2), a3(a3), a4(a4) {}
+        context53(F f, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4)
+            : f(f), c0(c0), c1(c1), c2(c2), c3(c3), c4(c4) {}
 
-        void operator()(B0 b0, B1 b1, B2 b2) {
-            f(a0, a1, a2, a3, a4, b0, b1, b2);
+        void operator()(A0 a0, A1 a1, A2 a2) {
+            f(c0, c1, c2, c3, c4, a0, a1, a2);
         }
     };
 
-    template <typename F, typename B0, typename B1, typename B2, typename B3>
+    template <typename F, typename A0, typename A1, typename A2, typename A3>
     struct context04 {
         F f;
 
         context04(F f)
             : f(f) {}
 
-        void operator()(B0 b0, B1 b1, B2 b2, B3 b3) {
-            f(b0, b1, b2, b3);
+        void operator()(A0 a0, A1 a1, A2 a2, A3 a3) {
+            f(a0, a1, a2, a3);
         }
     };
 
-    template <typename F, typename A0, typename B0, typename B1, typename B2, typename B3>
+    template <typename F, typename C0, typename A0, typename A1, typename A2, typename A3>
     struct context14 {
-        F f; A0 a0;
+        F f; C0 c0;
 
-        context14(F f, A0 a0)
-            : f(f), a0(a0) {}
+        context14(F f, C0 c0)
+            : f(f), c0(c0) {}
 
-        void operator()(B0 b0, B1 b1, B2 b2, B3 b3) {
-            f(a0, b0, b1, b2, b3);
+        void operator()(A0 a0, A1 a1, A2 a2, A3 a3) {
+            f(c0, a0, a1, a2, a3);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename B0, typename B1, typename B2, typename B3>
+    template <typename F, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
     struct context24 {
-        F f; A0 a0; A1 a1;
+        F f; C0 c0; C1 c1;
 
-        context24(F f, A0 a0, A1 a1)
-            : f(f), a0(a0), a1(a1) {}
+        context24(F f, C0 c0, C1 c1)
+            : f(f), c0(c0), c1(c1) {}
 
-        void operator()(B0 b0, B1 b1, B2 b2, B3 b3) {
-            f(a0, a1, b0, b1, b2, b3);
+        void operator()(A0 a0, A1 a1, A2 a2, A3 a3) {
+            f(c0, c1, a0, a1, a2, a3);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename A2, typename B0, typename B1, typename B2, typename B3>
+    template <typename F, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
     struct context34 {
-        F f; A0 a0; A1 a1; A2 a2;
+        F f; C0 c0; C1 c1; C2 c2;
 
-        context34(F f, A0 a0, A1 a1, A2 a2)
-            : f(f), a0(a0), a1(a1), a2(a2) {}
+        context34(F f, C0 c0, C1 c1, C2 c2)
+            : f(f), c0(c0), c1(c1), c2(c2) {}
 
-        void operator()(B0 b0, B1 b1, B2 b2, B3 b3) {
-            f(a0, a1, a2, b0, b1, b2, b3);
+        void operator()(A0 a0, A1 a1, A2 a2, A3 a3) {
+            f(c0, c1, c2, a0, a1, a2, a3);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename A2, typename A3, typename B0, typename B1, typename B2, typename B3>
+    template <typename F, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
     struct context44 {
-        F f; A0 a0; A1 a1; A2 a2; A3 a3;
+        F f; C0 c0; C1 c1; C2 c2; C3 c3;
 
-        context44(F f, A0 a0, A1 a1, A2 a2, A3 a3)
-            : f(f), a0(a0), a1(a1), a2(a2), a3(a3) {}
+        context44(F f, C0 c0, C1 c1, C2 c2, C3 c3)
+            : f(f), c0(c0), c1(c1), c2(c2), c3(c3) {}
 
-        void operator()(B0 b0, B1 b1, B2 b2, B3 b3) {
-            f(a0, a1, a2, a3, b0, b1, b2, b3);
+        void operator()(A0 a0, A1 a1, A2 a2, A3 a3) {
+            f(c0, c1, c2, c3, a0, a1, a2, a3);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4, typename B0, typename B1, typename B2, typename B3>
+    template <typename F, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
     struct context54 {
-        F f; A0 a0; A1 a1; A2 a2; A3 a3; A4 a4;
+        F f; C0 c0; C1 c1; C2 c2; C3 c3; C4 c4;
 
-        context54(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
-            : f(f), a0(a0), a1(a1), a2(a2), a3(a3), a4(a4) {}
+        context54(F f, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4)
+            : f(f), c0(c0), c1(c1), c2(c2), c3(c3), c4(c4) {}
 
-        void operator()(B0 b0, B1 b1, B2 b2, B3 b3) {
-            f(a0, a1, a2, a3, a4, b0, b1, b2, b3);
+        void operator()(A0 a0, A1 a1, A2 a2, A3 a3) {
+            f(c0, c1, c2, c3, c4, a0, a1, a2, a3);
         }
     };
 
-    template <typename F, typename B0, typename B1, typename B2, typename B3, typename B4>
+    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
     struct context05 {
         F f;
 
         context05(F f)
             : f(f) {}
 
-        void operator()(B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
-            f(b0, b1, b2, b3, b4);
+        void operator()(A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+            f(a0, a1, a2, a3, a4);
         }
     };
 
-    template <typename F, typename A0, typename B0, typename B1, typename B2, typename B3, typename B4>
+    template <typename F, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
     struct context15 {
-        F f; A0 a0;
+        F f; C0 c0;
 
-        context15(F f, A0 a0)
-            : f(f), a0(a0) {}
+        context15(F f, C0 c0)
+            : f(f), c0(c0) {}
 
-        void operator()(B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
-            f(a0, b0, b1, b2, b3, b4);
+        void operator()(A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+            f(c0, a0, a1, a2, a3, a4);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename B0, typename B1, typename B2, typename B3, typename B4>
+    template <typename F, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
     struct context25 {
-        F f; A0 a0; A1 a1;
+        F f; C0 c0; C1 c1;
 
-        context25(F f, A0 a0, A1 a1)
-            : f(f), a0(a0), a1(a1) {}
+        context25(F f, C0 c0, C1 c1)
+            : f(f), c0(c0), c1(c1) {}
 
-        void operator()(B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
-            f(a0, a1, b0, b1, b2, b3, b4);
+        void operator()(A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+            f(c0, c1, a0, a1, a2, a3, a4);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename A2, typename B0, typename B1, typename B2, typename B3, typename B4>
+    template <typename F, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
     struct context35 {
-        F f; A0 a0; A1 a1; A2 a2;
+        F f; C0 c0; C1 c1; C2 c2;
 
-        context35(F f, A0 a0, A1 a1, A2 a2)
-            : f(f), a0(a0), a1(a1), a2(a2) {}
+        context35(F f, C0 c0, C1 c1, C2 c2)
+            : f(f), c0(c0), c1(c1), c2(c2) {}
 
-        void operator()(B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
-            f(a0, a1, a2, b0, b1, b2, b3, b4);
+        void operator()(A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+            f(c0, c1, c2, a0, a1, a2, a3, a4);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename A2, typename A3, typename B0, typename B1, typename B2, typename B3, typename B4>
+    template <typename F, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
     struct context45 {
-        F f; A0 a0; A1 a1; A2 a2; A3 a3;
+        F f; C0 c0; C1 c1; C2 c2; C3 c3;
 
-        context45(F f, A0 a0, A1 a1, A2 a2, A3 a3)
-            : f(f), a0(a0), a1(a1), a2(a2), a3(a3) {}
+        context45(F f, C0 c0, C1 c1, C2 c2, C3 c3)
+            : f(f), c0(c0), c1(c1), c2(c2), c3(c3) {}
 
-        void operator()(B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
-            f(a0, a1, a2, a3, b0, b1, b2, b3, b4);
+        void operator()(A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+            f(c0, c1, c2, c3, a0, a1, a2, a3, a4);
         }
     };
 
-    template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4, typename B0, typename B1, typename B2, typename B3, typename B4>
+    template <typename F, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
     struct context55 {
-        F f; A0 a0; A1 a1; A2 a2; A3 a3; A4 a4;
+        F f; C0 c0; C1 c1; C2 c2; C3 c3; C4 c4;
 
-        context55(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4)
-            : f(f), a0(a0), a1(a1), a2(a2), a3(a3), a4(a4) {}
+        context55(F f, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4)
+            : f(f), c0(c0), c1(c1), c2(c2), c3(c3), c4(c4) {}
 
-        void operator()(B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
-            f(a0, a1, a2, a3, a4, b0, b1, b2, b3, b4);
+        void operator()(A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
+            f(c0, c1, c2, c3, c4, a0, a1, a2, a3, a4);
         }
     };
 };

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ EventQueue queue(32*EVENTS_EVENT_SIZE);
 // Events can be posted to the underlying event queue with dynamic
 // context allocated from the specified buffer
 queue.call(printf, "hello %d %d %d %d\n", 1, 2, 3, 4);
-queue.call(Callback<void()>(&serial, &Serial::printf), "hi\n");
+queue.call(&serial, &Serial::printf, "hi\n");
 
 // The dispatch function provides the context for the running the queue
 // and can take a millisecond timeout to run for a fixed time or to just

--- a/TESTS/events/queue/main.cpp
+++ b/TESTS/events/queue/main.cpp
@@ -216,6 +216,22 @@ void event_class_helper_test() {
     TEST_ASSERT_EQUAL(counter, 15);
 }
 
+void event_inference_test() {
+    counter = 0;
+    EventQueue queue (2048);
+
+    queue.event(count5, 1, 1, 1, 1, 1).post();
+    queue.event(count5, 1, 1, 1, 1).post(1);
+    queue.event(count5, 1, 1, 1).post(1, 1);
+    queue.event(count5, 1, 1).post(1, 1, 1);
+    queue.event(count5, 1).post(1, 1, 1, 1);
+    queue.event(count5).post(1, 1, 1, 1, 1);
+
+    queue.dispatch(0);
+
+    TEST_ASSERT_EQUAL(counter, 30);
+}
+
 
 // Test setup
 utest::v1::status_t test_setup(const size_t number_of_cases) {
@@ -240,6 +256,7 @@ const Case cases[] = {
     Case("Testing event cancel 1", cancel_test1<20>),
     Case("Testing the event class", event_class_test),
     Case("Testing the event class helpers", event_class_helper_test),
+    Case("Testing the event inference", event_inference_test),
 };
 
 Specification specification(test_setup, cases);


### PR DESCRIPTION
EventQueue::event is now defined for the following overloads:

``` cpp
event(R (*)(A...),                                       C...);
event(F,                                                 C...);
event(const F,                                           C...);
event(volatile F,                                        C...);
event(const volatile F,                                  C...);
event(T *,                R (T::*)(A...),                C...);
event(const T *,          R (T::*)(A...) const,          C...);
event(volatile T *,       R (T::*)(A...) volatile,       C...);
event(const volatile T *, R (T::*)(A...) const volatile, C...);
```

This insures cleaner error messages when invalid types are used.

It should be noted that different types are used for the infered function parameters and the arguments supplied to event, this is important for inducing implicit casts.

Otherwise, deceptively confusing bugs can occur:

``` cpp
    void doit(unsigned value);
    queue.event(doit, 1); // Error - 1 is signed without implicit casts
```

With the stricter type inference on the convenience event function, it is trivial to determine the quantity of parameters present in a function type.

With the arity of the function type, we can determine which Event class must be generated entirely based on type inference. This is a huge benefit to the value of the convenience event functions and removes any lingering limitations on the event function usage.
