### PR TITLE
Removed problematic event overloads for function-objects

### DIFF
--- a/Event.h
+++ b/Event.h
@@ -2413,34 +2413,6 @@ Event<void()> EventQueue::event(R (*func)()) {
     return Event<void()>(this, func);
 }
 
-template <typename F, typename R>
-Event<void()> EventQueue::event(F func, typename detail::enable_if<
-            detail::is_type<R (F::*)(), &F::operator()>::value
-        >::type) {
-    return Event<void()>(this, func);
-}
-
-template <typename F, typename R>
-Event<void()> EventQueue::event(const F func, typename detail::enable_if<
-            detail::is_type<R (F::*)() const, &F::operator()>::value
-        >::type) {
-    return Event<void()>(this, func);
-}
-
-template <typename F, typename R>
-Event<void()> EventQueue::event(volatile F func, typename detail::enable_if<
-            detail::is_type<R (F::*)() volatile, &F::operator()>::value
-        >::type) {
-    return Event<void()>(this, func);
-}
-
-template <typename F, typename R>
-Event<void()> EventQueue::event(const volatile F func, typename detail::enable_if<
-            detail::is_type<R (F::*)() const volatile, &F::operator()>::value
-        >::type) {
-    return Event<void()>(this, func);
-}
-
 template <typename T, typename R>
 Event<void()> EventQueue::event(T *obj, R (T::*method)()) {
     return Event<void()>(this, mbed::callback(obj, method));
@@ -2463,34 +2435,6 @@ Event<void()> EventQueue::event(const volatile T *obj, R (T::*method)() const vo
 
 template <typename R, typename B0, typename C0>
 Event<void()> EventQueue::event(R (*func)(B0), C0 c0) {
-    return Event<void()>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0>
-Event<void()> EventQueue::event(F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0), &F::operator()>::value
-        >::type) {
-    return Event<void()>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0>
-Event<void()> EventQueue::event(const F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0) const, &F::operator()>::value
-        >::type) {
-    return Event<void()>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0>
-Event<void()> EventQueue::event(volatile F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void()>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0>
-Event<void()> EventQueue::event(const volatile F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0) const volatile, &F::operator()>::value
-        >::type) {
     return Event<void()>(this, func, c0);
 }
 
@@ -2519,34 +2463,6 @@ Event<void()> EventQueue::event(R (*func)(B0, B1), C0 c0, C1 c1) {
     return Event<void()>(this, func, c0, c1);
 }
 
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1>
-Event<void()> EventQueue::event(F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1), &F::operator()>::value
-        >::type) {
-    return Event<void()>(this, func, c0, c1);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1>
-Event<void()> EventQueue::event(const F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1) const, &F::operator()>::value
-        >::type) {
-    return Event<void()>(this, func, c0, c1);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1>
-Event<void()> EventQueue::event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void()>(this, func, c0, c1);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1>
-Event<void()> EventQueue::event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1) const volatile, &F::operator()>::value
-        >::type) {
-    return Event<void()>(this, func, c0, c1);
-}
-
 template <typename T, typename R, typename B0, typename B1, typename C0, typename C1>
 Event<void()> EventQueue::event(T *obj, R (T::*method)(B0, B1), C0 c0, C1 c1) {
     return Event<void()>(this, mbed::callback(obj, method), c0, c1);
@@ -2569,34 +2485,6 @@ Event<void()> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1) co
 
 template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
 Event<void()> EventQueue::event(R (*func)(B0, B1, B2), C0 c0, C1 c1, C2 c2) {
-    return Event<void()>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
-Event<void()> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2), &F::operator()>::value
-        >::type) {
-    return Event<void()>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
-Event<void()> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2) const, &F::operator()>::value
-        >::type) {
-    return Event<void()>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
-Event<void()> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void()>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
-Event<void()> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2) const volatile, &F::operator()>::value
-        >::type) {
     return Event<void()>(this, func, c0, c1, c2);
 }
 
@@ -2625,34 +2513,6 @@ Event<void()> EventQueue::event(R (*func)(B0, B1, B2, B3), C0 c0, C1 c1, C2 c2, 
     return Event<void()>(this, func, c0, c1, c2, c3);
 }
 
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
-Event<void()> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3), &F::operator()>::value
-        >::type) {
-    return Event<void()>(this, func, c0, c1, c2, c3);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
-Event<void()> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3) const, &F::operator()>::value
-        >::type) {
-    return Event<void()>(this, func, c0, c1, c2, c3);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
-Event<void()> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void()>(this, func, c0, c1, c2, c3);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
-Event<void()> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3) const volatile, &F::operator()>::value
-        >::type) {
-    return Event<void()>(this, func, c0, c1, c2, c3);
-}
-
 template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
 Event<void()> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, B3), C0 c0, C1 c1, C2 c2, C3 c3) {
     return Event<void()>(this, mbed::callback(obj, method), c0, c1, c2, c3);
@@ -2675,34 +2535,6 @@ Event<void()> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, B2
 
 template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
 Event<void()> EventQueue::event(R (*func)(B0, B1, B2, B3, B4), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
-    return Event<void()>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
-Event<void()> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4), &F::operator()>::value
-        >::type) {
-    return Event<void()>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
-Event<void()> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4) const, &F::operator()>::value
-        >::type) {
-    return Event<void()>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
-Event<void()> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void()>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
-Event<void()> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4) const volatile, &F::operator()>::value
-        >::type) {
     return Event<void()>(this, func, c0, c1, c2, c3, c4);
 }
 
@@ -2731,34 +2563,6 @@ Event<void(A0)> EventQueue::event(R (*func)(A0)) {
     return Event<void(A0)>(this, func);
 }
 
-template <typename F, typename R, typename A0>
-Event<void(A0)> EventQueue::event(F func, typename detail::enable_if<
-            detail::is_type<R (F::*)(A0), &F::operator()>::value
-        >::type) {
-    return Event<void(A0)>(this, func);
-}
-
-template <typename F, typename R, typename A0>
-Event<void(A0)> EventQueue::event(const F func, typename detail::enable_if<
-            detail::is_type<R (F::*)(A0) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0)>(this, func);
-}
-
-template <typename F, typename R, typename A0>
-Event<void(A0)> EventQueue::event(volatile F func, typename detail::enable_if<
-            detail::is_type<R (F::*)(A0) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0)>(this, func);
-}
-
-template <typename F, typename R, typename A0>
-Event<void(A0)> EventQueue::event(const volatile F func, typename detail::enable_if<
-            detail::is_type<R (F::*)(A0) const volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0)>(this, func);
-}
-
 template <typename T, typename R, typename A0>
 Event<void(A0)> EventQueue::event(T *obj, R (T::*method)(A0)) {
     return Event<void(A0)>(this, mbed::callback(obj, method));
@@ -2781,34 +2585,6 @@ Event<void(A0)> EventQueue::event(const volatile T *obj, R (T::*method)(A0) cons
 
 template <typename R, typename B0, typename C0, typename A0>
 Event<void(A0)> EventQueue::event(R (*func)(B0, A0), C0 c0) {
-    return Event<void(A0)>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0, typename A0>
-Event<void(A0)> EventQueue::event(F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, A0), &F::operator()>::value
-        >::type) {
-    return Event<void(A0)>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0, typename A0>
-Event<void(A0)> EventQueue::event(const F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, A0) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0)>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0, typename A0>
-Event<void(A0)> EventQueue::event(volatile F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, A0) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0)>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0, typename A0>
-Event<void(A0)> EventQueue::event(const volatile F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, A0) const volatile, &F::operator()>::value
-        >::type) {
     return Event<void(A0)>(this, func, c0);
 }
 
@@ -2837,34 +2613,6 @@ Event<void(A0)> EventQueue::event(R (*func)(B0, B1, A0), C0 c0, C1 c1) {
     return Event<void(A0)>(this, func, c0, c1);
 }
 
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
-Event<void(A0)> EventQueue::event(F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, A0), &F::operator()>::value
-        >::type) {
-    return Event<void(A0)>(this, func, c0, c1);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
-Event<void(A0)> EventQueue::event(const F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, A0) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0)>(this, func, c0, c1);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
-Event<void(A0)> EventQueue::event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, A0) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0)>(this, func, c0, c1);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
-Event<void(A0)> EventQueue::event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, A0) const volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0)>(this, func, c0, c1);
-}
-
 template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
 Event<void(A0)> EventQueue::event(T *obj, R (T::*method)(B0, B1, A0), C0 c0, C1 c1) {
     return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1);
@@ -2887,34 +2635,6 @@ Event<void(A0)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, 
 
 template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
 Event<void(A0)> EventQueue::event(R (*func)(B0, B1, B2, A0), C0 c0, C1 c1, C2 c2) {
-    return Event<void(A0)>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
-Event<void(A0)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, A0), &F::operator()>::value
-        >::type) {
-    return Event<void(A0)>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
-Event<void(A0)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, A0) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0)>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
-Event<void(A0)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, A0) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0)>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
-Event<void(A0)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, A0) const volatile, &F::operator()>::value
-        >::type) {
     return Event<void(A0)>(this, func, c0, c1, c2);
 }
 
@@ -2943,34 +2663,6 @@ Event<void(A0)> EventQueue::event(R (*func)(B0, B1, B2, B3, A0), C0 c0, C1 c1, C
     return Event<void(A0)>(this, func, c0, c1, c2, c3);
 }
 
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
-Event<void(A0)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, A0), &F::operator()>::value
-        >::type) {
-    return Event<void(A0)>(this, func, c0, c1, c2, c3);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
-Event<void(A0)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, A0) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0)>(this, func, c0, c1, c2, c3);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
-Event<void(A0)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, A0) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0)>(this, func, c0, c1, c2, c3);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
-Event<void(A0)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, A0) const volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0)>(this, func, c0, c1, c2, c3);
-}
-
 template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
 Event<void(A0)> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, B3, A0), C0 c0, C1 c1, C2 c2, C3 c3) {
     return Event<void(A0)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
@@ -2993,34 +2685,6 @@ Event<void(A0)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, B1, 
 
 template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
 Event<void(A0)> EventQueue::event(R (*func)(B0, B1, B2, B3, B4, A0), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
-    return Event<void(A0)>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
-Event<void(A0)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0), &F::operator()>::value
-        >::type) {
-    return Event<void(A0)>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
-Event<void(A0)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0)>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
-Event<void(A0)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0)>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
-Event<void(A0)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0) const volatile, &F::operator()>::value
-        >::type) {
     return Event<void(A0)>(this, func, c0, c1, c2, c3, c4);
 }
 
@@ -3049,34 +2713,6 @@ Event<void(A0, A1)> EventQueue::event(R (*func)(A0, A1)) {
     return Event<void(A0, A1)>(this, func);
 }
 
-template <typename F, typename R, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(F func, typename detail::enable_if<
-            detail::is_type<R (F::*)(A0, A1), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1)>(this, func);
-}
-
-template <typename F, typename R, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(const F func, typename detail::enable_if<
-            detail::is_type<R (F::*)(A0, A1) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1)>(this, func);
-}
-
-template <typename F, typename R, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(volatile F func, typename detail::enable_if<
-            detail::is_type<R (F::*)(A0, A1) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1)>(this, func);
-}
-
-template <typename F, typename R, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(const volatile F func, typename detail::enable_if<
-            detail::is_type<R (F::*)(A0, A1) const volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1)>(this, func);
-}
-
 template <typename T, typename R, typename A0, typename A1>
 Event<void(A0, A1)> EventQueue::event(T *obj, R (T::*method)(A0, A1)) {
     return Event<void(A0, A1)>(this, mbed::callback(obj, method));
@@ -3099,34 +2735,6 @@ Event<void(A0, A1)> EventQueue::event(const volatile T *obj, R (T::*method)(A0, 
 
 template <typename R, typename B0, typename C0, typename A0, typename A1>
 Event<void(A0, A1)> EventQueue::event(R (*func)(B0, A0, A1), C0 c0) {
-    return Event<void(A0, A1)>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, A0, A1), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1)>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(const F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, A0, A1) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1)>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(volatile F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, A0, A1) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1)>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(const volatile F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, A0, A1) const volatile, &F::operator()>::value
-        >::type) {
     return Event<void(A0, A1)>(this, func, c0);
 }
 
@@ -3155,34 +2763,6 @@ Event<void(A0, A1)> EventQueue::event(R (*func)(B0, B1, A0, A1), C0 c0, C1 c1) {
     return Event<void(A0, A1)>(this, func, c0, c1);
 }
 
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, A0, A1), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1)>(this, func, c0, c1);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(const F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, A0, A1) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1)>(this, func, c0, c1);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, A0, A1) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1)>(this, func, c0, c1);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, A0, A1) const volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1)>(this, func, c0, c1);
-}
-
 template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
 Event<void(A0, A1)> EventQueue::event(T *obj, R (T::*method)(B0, B1, A0, A1), C0 c0, C1 c1) {
     return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1);
@@ -3205,34 +2785,6 @@ Event<void(A0, A1)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, 
 
 template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
 Event<void(A0, A1)> EventQueue::event(R (*func)(B0, B1, B2, A0, A1), C0 c0, C1 c1, C2 c2) {
-    return Event<void(A0, A1)>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, A0, A1), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1)>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, A0, A1) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1)>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, A0, A1) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1)>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, A0, A1) const volatile, &F::operator()>::value
-        >::type) {
     return Event<void(A0, A1)>(this, func, c0, c1, c2);
 }
 
@@ -3261,34 +2813,6 @@ Event<void(A0, A1)> EventQueue::event(R (*func)(B0, B1, B2, B3, A0, A1), C0 c0, 
     return Event<void(A0, A1)>(this, func, c0, c1, c2, c3);
 }
 
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1)>(this, func, c0, c1, c2, c3);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1)>(this, func, c0, c1, c2, c3);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1)>(this, func, c0, c1, c2, c3);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1) const volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1)>(this, func, c0, c1, c2, c3);
-}
-
 template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
 Event<void(A0, A1)> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1), C0 c0, C1 c1, C2 c2, C3 c3) {
     return Event<void(A0, A1)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
@@ -3311,34 +2835,6 @@ Event<void(A0, A1)> EventQueue::event(const volatile T *obj, R (T::*method)(B0, 
 
 template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
 Event<void(A0, A1)> EventQueue::event(R (*func)(B0, B1, B2, B3, B4, A0, A1), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
-    return Event<void(A0, A1)>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1)>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1)>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1)>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
-Event<void(A0, A1)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1) const volatile, &F::operator()>::value
-        >::type) {
     return Event<void(A0, A1)>(this, func, c0, c1, c2, c3, c4);
 }
 
@@ -3367,34 +2863,6 @@ Event<void(A0, A1, A2)> EventQueue::event(R (*func)(A0, A1, A2)) {
     return Event<void(A0, A1, A2)>(this, func);
 }
 
-template <typename F, typename R, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(F func, typename detail::enable_if<
-            detail::is_type<R (F::*)(A0, A1, A2), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2)>(this, func);
-}
-
-template <typename F, typename R, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(const F func, typename detail::enable_if<
-            detail::is_type<R (F::*)(A0, A1, A2) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2)>(this, func);
-}
-
-template <typename F, typename R, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(volatile F func, typename detail::enable_if<
-            detail::is_type<R (F::*)(A0, A1, A2) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2)>(this, func);
-}
-
-template <typename F, typename R, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(const volatile F func, typename detail::enable_if<
-            detail::is_type<R (F::*)(A0, A1, A2) const volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2)>(this, func);
-}
-
 template <typename T, typename R, typename A0, typename A1, typename A2>
 Event<void(A0, A1, A2)> EventQueue::event(T *obj, R (T::*method)(A0, A1, A2)) {
     return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method));
@@ -3417,34 +2885,6 @@ Event<void(A0, A1, A2)> EventQueue::event(const volatile T *obj, R (T::*method)(
 
 template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
 Event<void(A0, A1, A2)> EventQueue::event(R (*func)(B0, A0, A1, A2), C0 c0) {
-    return Event<void(A0, A1, A2)>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, A0, A1, A2), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2)>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(const F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, A0, A1, A2) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2)>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(volatile F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, A0, A1, A2) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2)>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(const volatile F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, A0, A1, A2) const volatile, &F::operator()>::value
-        >::type) {
     return Event<void(A0, A1, A2)>(this, func, c0);
 }
 
@@ -3473,34 +2913,6 @@ Event<void(A0, A1, A2)> EventQueue::event(R (*func)(B0, B1, A0, A1, A2), C0 c0, 
     return Event<void(A0, A1, A2)>(this, func, c0, c1);
 }
 
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, A0, A1, A2), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2)>(this, func, c0, c1);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(const F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, A0, A1, A2) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2)>(this, func, c0, c1);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, A0, A1, A2) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2)>(this, func, c0, c1);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, A0, A1, A2) const volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2)>(this, func, c0, c1);
-}
-
 template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
 Event<void(A0, A1, A2)> EventQueue::event(T *obj, R (T::*method)(B0, B1, A0, A1, A2), C0 c0, C1 c1) {
     return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1);
@@ -3523,34 +2935,6 @@ Event<void(A0, A1, A2)> EventQueue::event(const volatile T *obj, R (T::*method)(
 
 template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
 Event<void(A0, A1, A2)> EventQueue::event(R (*func)(B0, B1, B2, A0, A1, A2), C0 c0, C1 c1, C2 c2) {
-    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2) const volatile, &F::operator()>::value
-        >::type) {
     return Event<void(A0, A1, A2)>(this, func, c0, c1, c2);
 }
 
@@ -3579,34 +2963,6 @@ Event<void(A0, A1, A2)> EventQueue::event(R (*func)(B0, B1, B2, B3, A0, A1, A2),
     return Event<void(A0, A1, A2)>(this, func, c0, c1, c2, c3);
 }
 
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2, c3);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2, c3);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2, c3);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2) const volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2, c3);
-}
-
 template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
 Event<void(A0, A1, A2)> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2), C0 c0, C1 c1, C2 c2, C3 c3) {
     return Event<void(A0, A1, A2)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
@@ -3629,34 +2985,6 @@ Event<void(A0, A1, A2)> EventQueue::event(const volatile T *obj, R (T::*method)(
 
 template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
 Event<void(A0, A1, A2)> EventQueue::event(R (*func)(B0, B1, B2, B3, B4, A0, A1, A2), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
-    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2)>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
-Event<void(A0, A1, A2)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2) const volatile, &F::operator()>::value
-        >::type) {
     return Event<void(A0, A1, A2)>(this, func, c0, c1, c2, c3, c4);
 }
 
@@ -3685,34 +3013,6 @@ Event<void(A0, A1, A2, A3)> EventQueue::event(R (*func)(A0, A1, A2, A3)) {
     return Event<void(A0, A1, A2, A3)>(this, func);
 }
 
-template <typename F, typename R, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(F func, typename detail::enable_if<
-            detail::is_type<R (F::*)(A0, A1, A2, A3), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3)>(this, func);
-}
-
-template <typename F, typename R, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(const F func, typename detail::enable_if<
-            detail::is_type<R (F::*)(A0, A1, A2, A3) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3)>(this, func);
-}
-
-template <typename F, typename R, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(volatile F func, typename detail::enable_if<
-            detail::is_type<R (F::*)(A0, A1, A2, A3) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3)>(this, func);
-}
-
-template <typename F, typename R, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile F func, typename detail::enable_if<
-            detail::is_type<R (F::*)(A0, A1, A2, A3) const volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3)>(this, func);
-}
-
 template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
 Event<void(A0, A1, A2, A3)> EventQueue::event(T *obj, R (T::*method)(A0, A1, A2, A3)) {
     return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method));
@@ -3735,34 +3035,6 @@ Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile T *obj, R (T::*meth
 
 template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
 Event<void(A0, A1, A2, A3)> EventQueue::event(R (*func)(B0, A0, A1, A2, A3), C0 c0) {
-    return Event<void(A0, A1, A2, A3)>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, A0, A1, A2, A3), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3)>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(const F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, A0, A1, A2, A3) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3)>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(volatile F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, A0, A1, A2, A3) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3)>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, A0, A1, A2, A3) const volatile, &F::operator()>::value
-        >::type) {
     return Event<void(A0, A1, A2, A3)>(this, func, c0);
 }
 
@@ -3791,34 +3063,6 @@ Event<void(A0, A1, A2, A3)> EventQueue::event(R (*func)(B0, B1, A0, A1, A2, A3),
     return Event<void(A0, A1, A2, A3)>(this, func, c0, c1);
 }
 
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(const F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3) const volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1);
-}
-
 template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
 Event<void(A0, A1, A2, A3)> EventQueue::event(T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3), C0 c0, C1 c1) {
     return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1);
@@ -3841,34 +3085,6 @@ Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile T *obj, R (T::*meth
 
 template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
 Event<void(A0, A1, A2, A3)> EventQueue::event(R (*func)(B0, B1, B2, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2) {
-    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3) const volatile, &F::operator()>::value
-        >::type) {
     return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2);
 }
 
@@ -3897,34 +3113,6 @@ Event<void(A0, A1, A2, A3)> EventQueue::event(R (*func)(B0, B1, B2, B3, A0, A1, 
     return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2, c3);
 }
 
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2, c3);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2, c3);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2, c3);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3) const volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2, c3);
-}
-
 template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
 Event<void(A0, A1, A2, A3)> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2, C3 c3) {
     return Event<void(A0, A1, A2, A3)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
@@ -3947,34 +3135,6 @@ Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile T *obj, R (T::*meth
 
 template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
 Event<void(A0, A1, A2, A3)> EventQueue::event(R (*func)(B0, B1, B2, B3, B4, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
-    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
-Event<void(A0, A1, A2, A3)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3) const volatile, &F::operator()>::value
-        >::type) {
     return Event<void(A0, A1, A2, A3)>(this, func, c0, c1, c2, c3, c4);
 }
 
@@ -4003,34 +3163,6 @@ Event<void(A0, A1, A2, A3, A4)> EventQueue::event(R (*func)(A0, A1, A2, A3, A4))
     return Event<void(A0, A1, A2, A3, A4)>(this, func);
 }
 
-template <typename F, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(F func, typename detail::enable_if<
-            detail::is_type<R (F::*)(A0, A1, A2, A3, A4), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func);
-}
-
-template <typename F, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const F func, typename detail::enable_if<
-            detail::is_type<R (F::*)(A0, A1, A2, A3, A4) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func);
-}
-
-template <typename F, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(volatile F func, typename detail::enable_if<
-            detail::is_type<R (F::*)(A0, A1, A2, A3, A4) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func);
-}
-
-template <typename F, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile F func, typename detail::enable_if<
-            detail::is_type<R (F::*)(A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func);
-}
-
 template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
 Event<void(A0, A1, A2, A3, A4)> EventQueue::event(T *obj, R (T::*method)(A0, A1, A2, A3, A4)) {
     return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method));
@@ -4053,34 +3185,6 @@ Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile T *obj, R (T::*
 
 template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
 Event<void(A0, A1, A2, A3, A4)> EventQueue::event(R (*func)(B0, A0, A1, A2, A3, A4), C0 c0) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, A0, A1, A2, A3, A4), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, A0, A1, A2, A3, A4) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(volatile F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, A0, A1, A2, A3, A4) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0);
-}
-
-template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile F func, C0 c0, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
-        >::type) {
     return Event<void(A0, A1, A2, A3, A4)>(this, func, c0);
 }
 
@@ -4109,34 +3213,6 @@ Event<void(A0, A1, A2, A3, A4)> EventQueue::event(R (*func)(B0, B1, A0, A1, A2, 
     return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1);
 }
 
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3, A4), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3, A4) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3, A4) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1);
-}
-
 template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
 Event<void(A0, A1, A2, A3, A4)> EventQueue::event(T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3, A4), C0 c0, C1 c1) {
     return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1);
@@ -4159,34 +3235,6 @@ Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile T *obj, R (T::*
 
 template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
 Event<void(A0, A1, A2, A3, A4)> EventQueue::event(R (*func)(B0, B1, B2, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3, A4), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3, A4) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3, A4) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
-        >::type) {
     return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2);
 }
 
@@ -4215,34 +3263,6 @@ Event<void(A0, A1, A2, A3, A4)> EventQueue::event(R (*func)(B0, B1, B2, B3, A0, 
     return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2, c3);
 }
 
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3, A4), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2, c3);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3, A4) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2, c3);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3, A4) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2, c3);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2, c3);
-}
-
 template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
 Event<void(A0, A1, A2, A3, A4)> EventQueue::event(T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2, C3 c3) {
     return Event<void(A0, A1, A2, A3, A4)>(this, mbed::callback(obj, method), c0, c1, c2, c3);
@@ -4265,34 +3285,6 @@ Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile T *obj, R (T::*
 
 template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
 Event<void(A0, A1, A2, A3, A4)> EventQueue::event(R (*func)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4), &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) const, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) volatile, &F::operator()>::value
-        >::type) {
-    return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2, c3, c4);
-}
-
-template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
-Event<void(A0, A1, A2, A3, A4)> EventQueue::event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-            detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
-        >::type) {
     return Event<void(A0, A1, A2, A3, A4)>(this, func, c0, c1, c2, c3, c4);
 }
 

--- a/EventQueue.h
+++ b/EventQueue.h
@@ -40,26 +40,6 @@ namespace events {
 template <typename F>
 class Event;
 
-// Internal sfinae declarations
-//
-// These are used to eliminate overloads based on member function types.
-// Handled cleanly by the compiler, these avoid massive and misleading error
-// messages when confronted with an invalid type (or worse, runtime failures)
-namespace detail {
-    struct nil {};
-
-    template <bool B, typename R = nil>
-    struct enable_if { typedef R type; };
-
-    template <typename R>
-    struct enable_if<false, R> {};
-
-    template <typename M, M>
-    struct is_type {
-        static const bool value = true;
-    };
-}
-
 
 /** EventQueue
  *
@@ -986,38 +966,6 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename R>
-    Event<void()> event(F func, typename detail::enable_if<
-                detail::is_type<R (F::*)(), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R>
-    Event<void()> event(const F func, typename detail::enable_if<
-                detail::is_type<R (F::*)() const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R>
-    Event<void()> event(volatile F func, typename detail::enable_if<
-                detail::is_type<R (F::*)() volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R>
-    Event<void()> event(const volatile F func, typename detail::enable_if<
-                detail::is_type<R (F::*)() const volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
     template <typename T, typename R>
     Event<void()> event(T *obj, R (T::*method)());
 
@@ -1044,38 +992,6 @@ public:
      */
     template <typename R, typename B0, typename C0>
     Event<void()> event(R (*func)(B0), C0 c0);
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0>
-    Event<void()> event(F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0>
-    Event<void()> event(const F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0>
-    Event<void()> event(volatile F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0>
-    Event<void()> event(const volatile F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0) const volatile, &F::operator()>::value
-            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1110,38 +1026,6 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1>
-    Event<void()> event(F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1>
-    Event<void()> event(const F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1>
-    Event<void()> event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1>
-    Event<void()> event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1) const volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1>
     Event<void()> event(T *obj, R (T::*method)(B0, B1), C0 c0, C1 c1);
 
@@ -1168,38 +1052,6 @@ public:
      */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
     Event<void()> event(R (*func)(B0, B1, B2), C0 c0, C1 c1, C2 c2);
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
-    Event<void()> event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
-    Event<void()> event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
-    Event<void()> event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
-    Event<void()> event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2) const volatile, &F::operator()>::value
-            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1234,38 +1086,6 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
-    Event<void()> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
-    Event<void()> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
-    Event<void()> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
-    Event<void()> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3) const volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
     Event<void()> event(T *obj, R (T::*method)(B0, B1, B2, B3), C0 c0, C1 c1, C2 c2, C3 c3);
 
@@ -1292,38 +1112,6 @@ public:
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
     Event<void()> event(R (*func)(B0, B1, B2, B3, B4), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
-    Event<void()> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
-    Event<void()> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
-    Event<void()> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
-    Event<void()> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4) const volatile, &F::operator()>::value
-            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1358,38 +1146,6 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename R, typename A0>
-    Event<void(A0)> event(F func, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename A0>
-    Event<void(A0)> event(const F func, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename A0>
-    Event<void(A0)> event(volatile F func, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename A0>
-    Event<void(A0)> event(const volatile F func, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0) const volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
     template <typename T, typename R, typename A0>
     Event<void(A0)> event(T *obj, R (T::*method)(A0));
 
@@ -1416,38 +1172,6 @@ public:
      */
     template <typename R, typename B0, typename C0, typename A0>
     Event<void(A0)> event(R (*func)(B0, A0), C0 c0);
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0, typename A0>
-    Event<void(A0)> event(F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, A0), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0, typename A0>
-    Event<void(A0)> event(const F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, A0) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0, typename A0>
-    Event<void(A0)> event(volatile F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, A0) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0, typename A0>
-    Event<void(A0)> event(const volatile F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, A0) const volatile, &F::operator()>::value
-            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1482,38 +1206,6 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
-    Event<void(A0)> event(F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, A0), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
-    Event<void(A0)> event(const F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, A0) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
-    Event<void(A0)> event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, A0) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
-    Event<void(A0)> event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, A0) const volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
     Event<void(A0)> event(T *obj, R (T::*method)(B0, B1, A0), C0 c0, C1 c1);
 
@@ -1540,38 +1232,6 @@ public:
      */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
     Event<void(A0)> event(R (*func)(B0, B1, B2, A0), C0 c0, C1 c1, C2 c2);
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
-    Event<void(A0)> event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, A0), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
-    Event<void(A0)> event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, A0) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
-    Event<void(A0)> event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, A0) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
-    Event<void(A0)> event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, A0) const volatile, &F::operator()>::value
-            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1606,38 +1266,6 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
-    Event<void(A0)> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, A0), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
-    Event<void(A0)> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, A0) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
-    Event<void(A0)> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, A0) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
-    Event<void(A0)> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, A0) const volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
     Event<void(A0)> event(T *obj, R (T::*method)(B0, B1, B2, B3, A0), C0 c0, C1 c1, C2 c2, C3 c3);
 
@@ -1664,38 +1292,6 @@ public:
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
     Event<void(A0)> event(R (*func)(B0, B1, B2, B3, B4, A0), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
-    Event<void(A0)> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
-    Event<void(A0)> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
-    Event<void(A0)> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
-    Event<void(A0)> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0) const volatile, &F::operator()>::value
-            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1730,38 +1326,6 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename R, typename A0, typename A1>
-    Event<void(A0, A1)> event(F func, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename A0, typename A1>
-    Event<void(A0, A1)> event(const F func, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename A0, typename A1>
-    Event<void(A0, A1)> event(volatile F func, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename A0, typename A1>
-    Event<void(A0, A1)> event(const volatile F func, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1) const volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
     template <typename T, typename R, typename A0, typename A1>
     Event<void(A0, A1)> event(T *obj, R (T::*method)(A0, A1));
 
@@ -1788,38 +1352,6 @@ public:
      */
     template <typename R, typename B0, typename C0, typename A0, typename A1>
     Event<void(A0, A1)> event(R (*func)(B0, A0, A1), C0 c0);
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1>
-    Event<void(A0, A1)> event(F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, A0, A1), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1>
-    Event<void(A0, A1)> event(const F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, A0, A1) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1>
-    Event<void(A0, A1)> event(volatile F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, A0, A1) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1>
-    Event<void(A0, A1)> event(const volatile F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, A0, A1) const volatile, &F::operator()>::value
-            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1854,38 +1386,6 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
-    Event<void(A0, A1)> event(F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, A0, A1), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
-    Event<void(A0, A1)> event(const F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, A0, A1) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
-    Event<void(A0, A1)> event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, A0, A1) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
-    Event<void(A0, A1)> event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, A0, A1) const volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
     Event<void(A0, A1)> event(T *obj, R (T::*method)(B0, B1, A0, A1), C0 c0, C1 c1);
 
@@ -1912,38 +1412,6 @@ public:
      */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
     Event<void(A0, A1)> event(R (*func)(B0, B1, B2, A0, A1), C0 c0, C1 c1, C2 c2);
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
-    Event<void(A0, A1)> event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, A0, A1), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
-    Event<void(A0, A1)> event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, A0, A1) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
-    Event<void(A0, A1)> event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, A0, A1) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
-    Event<void(A0, A1)> event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, A0, A1) const volatile, &F::operator()>::value
-            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -1978,38 +1446,6 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
-    Event<void(A0, A1)> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
-    Event<void(A0, A1)> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
-    Event<void(A0, A1)> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
-    Event<void(A0, A1)> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1) const volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
     Event<void(A0, A1)> event(T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1), C0 c0, C1 c1, C2 c2, C3 c3);
 
@@ -2036,38 +1472,6 @@ public:
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
     Event<void(A0, A1)> event(R (*func)(B0, B1, B2, B3, B4, A0, A1), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
-    Event<void(A0, A1)> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
-    Event<void(A0, A1)> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
-    Event<void(A0, A1)> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
-    Event<void(A0, A1)> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1) const volatile, &F::operator()>::value
-            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -2102,38 +1506,6 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename R, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(F func, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(const F func, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(volatile F func, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(const volatile F func, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2) const volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
     template <typename T, typename R, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(T *obj, R (T::*method)(A0, A1, A2));
 
@@ -2160,38 +1532,6 @@ public:
      */
     template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(R (*func)(B0, A0, A1, A2), C0 c0);
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, A0, A1, A2), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(const F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, A0, A1, A2) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(volatile F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, A0, A1, A2) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(const volatile F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, A0, A1, A2) const volatile, &F::operator()>::value
-            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -2226,38 +1566,6 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, A0, A1, A2), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(const F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, A0, A1, A2) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, A0, A1, A2) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, A0, A1, A2) const volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(T *obj, R (T::*method)(B0, B1, A0, A1, A2), C0 c0, C1 c1);
 
@@ -2284,38 +1592,6 @@ public:
      */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(R (*func)(B0, B1, B2, A0, A1, A2), C0 c0, C1 c1, C2 c2);
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2) const volatile, &F::operator()>::value
-            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -2350,38 +1626,6 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2) const volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2), C0 c0, C1 c1, C2 c2, C3 c3);
 
@@ -2408,38 +1652,6 @@ public:
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(R (*func)(B0, B1, B2, B3, B4, A0, A1, A2), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
-    Event<void(A0, A1, A2)> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2) const volatile, &F::operator()>::value
-            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -2474,38 +1686,6 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename R, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(F func, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(const F func, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(volatile F func, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(const volatile F func, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3) const volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(T *obj, R (T::*method)(A0, A1, A2, A3));
 
@@ -2532,38 +1712,6 @@ public:
      */
     template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(R (*func)(B0, A0, A1, A2, A3), C0 c0);
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, A0, A1, A2, A3), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(const F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, A0, A1, A2, A3) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(volatile F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, A0, A1, A2, A3) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(const volatile F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, A0, A1, A2, A3) const volatile, &F::operator()>::value
-            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -2598,38 +1746,6 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(const F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3) const volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3), C0 c0, C1 c1);
 
@@ -2656,38 +1772,6 @@ public:
      */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(R (*func)(B0, B1, B2, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2);
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3) const volatile, &F::operator()>::value
-            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -2722,38 +1806,6 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3) const volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2, C3 c3);
 
@@ -2780,38 +1832,6 @@ public:
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(R (*func)(B0, B1, B2, B3, B4, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
-    Event<void(A0, A1, A2, A3)> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3) const volatile, &F::operator()>::value
-            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -2846,38 +1866,6 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(F func, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3, A4), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(const F func, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3, A4) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(volatile F func, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3, A4) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(const volatile F func, typename detail::enable_if<
-                detail::is_type<R (F::*)(A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(T *obj, R (T::*method)(A0, A1, A2, A3, A4));
 
@@ -2904,38 +1892,6 @@ public:
      */
     template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(R (*func)(B0, A0, A1, A2, A3, A4), C0 c0);
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, A0, A1, A2, A3, A4), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(const F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, A0, A1, A2, A3, A4) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(volatile F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, A0, A1, A2, A3, A4) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(const volatile F func, C0 c0, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
-            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -2970,38 +1926,6 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3, A4), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(const F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3, A4) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3, A4) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(const volatile F func, C0 c0, C1 c1, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3, A4), C0 c0, C1 c1);
 
@@ -3028,38 +1952,6 @@ public:
      */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(R (*func)(B0, B1, B2, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2);
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3, A4), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(const F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3, A4) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3, A4) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(const volatile F func, C0 c0, C1 c1, C2 c2, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
-            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
@@ -3094,38 +1986,6 @@ public:
     /** Creates an event bound to the event queue
      *  @see EventQueue::event
      */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3, A4), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3, A4) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3, A4) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2, C3 c3);
 
@@ -3152,38 +2012,6 @@ public:
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(R (*func)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4), &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(const F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) const, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) volatile, &F::operator()>::value
-            >::type = detail::nil());
-
-    /** Creates an event bound to the event queue
-     *  @see EventQueue::event
-     */
-    template <typename F, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
-    Event<void(A0, A1, A2, A3, A4)> event(const volatile F func, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4, typename detail::enable_if<
-                detail::is_type<R (F::*)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) const volatile, &F::operator()>::value
-            >::type = detail::nil());
 
     /** Creates an event bound to the event queue
      *  @see EventQueue::event


### PR DESCRIPTION
Unfortunately, it is very difficult to infer the parameters of a function-object generically in C++03 without any additional type information. The current implementation fails to do so, and the compiler simply bails with "unable to deduce template parameter".

Rather than leaving the user with a small novel of error messages, this patch removes the problematic event overloads, leaving only event overloads for simple pointer types. As a side effect, the limited sfinae in mbed-events is no longer needed.
