### PR TITLE
events - Fixed overflow of timeout on STM32F4

### DIFF
--- a/equeue/equeue_mbed.cpp
+++ b/equeue/equeue_mbed.cpp
@@ -110,7 +110,9 @@ static void equeue_sema_timeout(equeue_sema_t *s) {
 bool equeue_sema_wait(equeue_sema_t *s, int ms) {
     int signal = 0;
     Timeout timeout;
-    timeout.attach_us(s, equeue_sema_timeout, ms*1000);
+    if (ms < 0) {
+        timeout.attach_us(Callback<void()>(equeue_sema_timeout, s), ms*1000);
+    }
 
     core_util_critical_section_enter();
     while (!*s) {


### PR DESCRIPTION
For equeue_sema_wait, -1 is used to indicate an infinite wait. This wasn't handled in the nonrtos implementation and caused undefined/weird behaviour after an overflow on integer multiplication.

On most boards, the infinite wait would return after ~50 days, on the STM32F4 the timeout killed all other timeouts for some reason.

tested on NUCLEO_F401RE
mirrored on https://github.com/ARMmbed/mbed-os/pull/3550